### PR TITLE
Bruk READER_TOKEN i stedet for GitHub App

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -69,17 +69,12 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
       - name: Push Docker image
         run: docker push $IMAGE
-      - uses: navikt/github-app-token-generator@v1.1
-        id: get-token
-        with:
-          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
-          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
       - name: Checkout e2e tests
         if: "!contains(needs.pre_ci.outputs.commit_message, 'e2e skip')"
         uses: actions/checkout@v2.3.4
         with:
           repository: navikt/familie-ba-e2e
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ secrets.READER_TOKEN }}
           path: ba-e2e
       - name: Setter riktig ba-mottak versjon i e2e tester
         if: "!contains(needs.pre_ci.outputs.commit_message, 'e2e skip')"

--- a/.github/workflows/build-dependabot.yml
+++ b/.github/workflows/build-dependabot.yml
@@ -41,17 +41,12 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
       - name: Push Docker image
         run: docker push $IMAGE
-      - uses: navikt/github-app-token-generator@v1.1
-        id: get-token
-        with:
-          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
-          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
       - name: Checkout e2e tests
         if: "!contains(github.event.head_commit.message, 'e2e skip')"
         uses: actions/checkout@v2.3.4
         with:
           repository: navikt/familie-ba-e2e
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ secrets.READER_TOKEN }}
           path: ba-e2e
       - name: Setter riktig ba-mottak versjon i e2e tester
         if: "!contains(github.event.head_commit.message, 'e2e skip')"

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -38,16 +38,11 @@ jobs:
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
       - name: Push Docker image
         run: docker push $IMAGE
-      - uses: navikt/github-app-token-generator@v1.1
-        id: get-token
-        with:
-          private-key: ${{ secrets.REPO_CLONER_PRIVATE_KEY }}
-          app-id: ${{ secrets.REPO_CLONER_APP_ID }}
       - name: Checkout e2e tests
         uses: actions/checkout@v2.3.4
         with:
           repository: navikt/familie-ba-e2e
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ secrets.READER_TOKEN }}
           path: ba-e2e
       - name: Setter riktig ba-mottak versjon i e2e tester
         run: sed -i 's/familie-ba-mottak:latest/familie-ba-mottak:'$GITHUB_SHA'/g' ba-e2e/e2e/docker-compose.yml


### PR DESCRIPTION
Vi har rullet ut en ny org-wide secret som kan brukes for å sjekke ut andre repos og hente pakker i en workflow. Denne PRen bytter derfor ut installation tokens med den nye secreten.
