### PR TITLE
Fiks counter id til søknad på papir

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/mottak/hendelser/JournalhendelseService.kt
@@ -33,8 +33,8 @@ class JournalhendelseService(
 
     val kanalNavnoCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.navno")
     val kanalSkannetsCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skannets")
-    val skannetOrdinæreSøknaderCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skannets.ny.ordinærsøknad")
-    val skannetUtvidedeSøknaderCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skannets.ny.utvidetsøknad")
+    val skannetOrdinæreSøknaderCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skan.ny.ordinaer.soknad")
+    val skannetUtvidedeSøknaderCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skan.ny.utvidet.soknad")
     val kanalAnnetCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.annet")
     val ignorerteCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.ignorerte")
     val feilCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.feilet")


### PR DESCRIPTION
Fikser counter id til søknaden sånn at den ikke bruke æ ø å 