### PR TITLE
skrur av aiven leesah midlertidig

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahConsumer.kt
@@ -33,7 +33,8 @@ class LeesahConsumer(val leesahService: LeesahService) {
         topics = ["pdl.leesah-v1"],
         id = "leesah-1",
         idIsGroup = false,
-        containerFactory = "kafkaAivenHendelseListenerAvroLatestContainerFactory" // TODO byttest til Earliest etter at onprem er av
+        containerFactory = "kafkaAivenHendelseListenerAvroEarliestContainerFactory",
+        autoStartup = "false"
     )
     @Transactional
     fun listen(cr: ConsumerRecord<String, Personhendelse>, ack: Acknowledgment) {
@@ -56,7 +57,7 @@ class LeesahConsumer(val leesahService: LeesahService) {
         try {
             MDC.put(MDCConstants.MDC_CALL_ID, pdlHendelse.hendelseId)
             SECURE_LOGGER.info("LeeasahConsumer har mottatt leesah-hendelse $cr")
-//            leesahService.prosesserNyHendelse(pdlHendelse) //TODO kommenteres inn igjen etter at onprem er av
+            leesahService.prosesserNyHendelse(pdlHendelse)
         } catch (e: RuntimeException) {
             leesahFeiletCounter.increment()
             SECURE_LOGGER.error("Feil i prosessering av leesah-hendelser", e)


### PR DESCRIPTION
- Oppdatering av prosessering, hvor jdbc-modulen er fjernet og byttet med core (#741)
- Bump felles.version from 1.20220930133126_14f75ec to 1.20221006150009_46021ed (#735)
- Bump postgresql from 1.17.4 to 1.17.5 (#732)
- Bump kontrakter.version from 2.0_20220916130234_aa8ba65 to 2.0_20221018121204_ee60849 (#742)
- Bump prosessering-core (#743)
- Bump kontrakter.version (#744)
- Lytter på leesah fra onprem uten å gjøre noe (#745)
- Skrur av aivin consumeren midlertidig, før vi skrur av onprem, før vi enabler aivin igjen
