### PR TITLE
Ikke sette behandlesAvApplikasjon på VurderLivshendelse-oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapper.kt
@@ -124,9 +124,3 @@ class OppgaveMapper(
         }
     }
 }
-
-enum class BehandlesAvApplikasjon(val applikasjon: String?) {
-    BA_SAK("familie-ba-sak"),
-    INFOTRYGD(null),
-    UAVKLART(null)
-}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -2,7 +2,6 @@ package no.nav.familie.baks.mottak.task
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
-import no.nav.familie.baks.mottak.integrasjoner.BehandlesAvApplikasjon
 import no.nav.familie.baks.mottak.integrasjoner.BehandlingKategori
 import no.nav.familie.baks.mottak.integrasjoner.BehandlingUnderkategori
 import no.nav.familie.baks.mottak.integrasjoner.FagsakDeltagerRolle.BARN
@@ -353,8 +352,7 @@ class VurderLivshendelseTask(
                 aktørId = aktørId,
                 beskrivelse = beskrivelse,
                 saksId = fagsakId.toString(),
-                behandlingstema = behandlingstema.value,
-                behandlesAvApplikasjon = BehandlesAvApplikasjon.BA_SAK.applikasjon
+                behandlingstema = behandlingstema.value
             )
         )
     }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTaskTest.kt
@@ -5,7 +5,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import no.nav.familie.baks.mottak.integrasjoner.BehandlesAvApplikasjon
 import no.nav.familie.baks.mottak.integrasjoner.BehandlingKategori
 import no.nav.familie.baks.mottak.integrasjoner.BehandlingUnderkategori
 import no.nav.familie.baks.mottak.integrasjoner.Dødsfall
@@ -290,7 +289,7 @@ class VurderLivshendelseTaskTest {
         assertThat(oppgaveDto).allMatch { it.saksId == "$SAKS_ID" }
         assertThat(oppgaveDto).allMatch { it.enhetsId == null }
         assertThat(oppgaveDto).allMatch { it.behandlingstema == Behandlingstema.UtvidetBarnetrygd.value }
-        assertThat(oppgaveDto).allMatch { it.behandlesAvApplikasjon == BehandlesAvApplikasjon.BA_SAK.applikasjon }
+        assertThat(oppgaveDto).allMatch { it.behandlesAvApplikasjon == null }
     }
 
     @Test
@@ -502,7 +501,7 @@ class VurderLivshendelseTaskTest {
         assertThat(oppgaveDto).allMatch { it.saksId == "$SAKS_ID" }
         assertThat(oppgaveDto).allMatch { it.enhetsId == null }
         assertThat(oppgaveDto).allMatch { it.behandlingstema == Behandlingstema.UtvidetBarnetrygd.value }
-        assertThat(oppgaveDto).allMatch { it.behandlesAvApplikasjon == BehandlesAvApplikasjon.BA_SAK.applikasjon }
+        assertThat(oppgaveDto).allMatch { it.behandlesAvApplikasjon == null }
     }
 
     @Test


### PR DESCRIPTION
Gosys ønsker å sperre for ferdigstilling av VurderLivshendelse-oppgave hvor behandlesAvApplikasjon er satt. For VurderLivshendelse-oppgaver så ønsker vi at man fortsatt skal kunne ferdigstille fra Gosys