### PR TITLE
Oppdatert måte å finne berørte fagsaker+aktører for sivilstand-hendelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClient.kt
@@ -107,15 +107,6 @@ class SakClient @Autowired constructor(
         )
     }
 
-    data class RestPersonIdent(
-        val personIdent: String
-    )
-
-    data class RestFagsakIdOgTilknyttetAktørId(
-        val aktørId: String,
-        val fagsakId: Long
-    )
-
     fun hentMinimalRestFagsak(fagsakId: Long): RestMinimalFagsak {
         val uri = URI.create("$sakServiceUri/fagsaker/minimal/$fagsakId")
         return runCatching {
@@ -150,6 +141,15 @@ class SakClient @Autowired constructor(
         }
     }
 }
+
+data class RestPersonIdent(
+    val personIdent: String
+)
+
+data class RestFagsakIdOgTilknyttetAktørId(
+    val aktørId: String,
+    val fagsakId: Long
+)
 
 data class RestMinimalFagsak(
     val id: Long,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClient.kt
@@ -107,6 +107,18 @@ class SakClient @Autowired constructor(
         )
     }
 
+    fun hentFagsakerHvorPersonMottarLøpendeUtvidetEllerOrdinærBarnetrygd(
+        personIdent: String
+    ): List<RestFagsakIdOgTilknyttetAktørId> {
+        val uri = URI.create("$sakServiceUri/fagsaker/sok/fagsaker-hvor-person-mottar-lopende-ytelse")
+        return runCatching {
+            postForEntity<Ressurs<List<RestFagsakIdOgTilknyttetAktørId>>>(uri, RestPersonIdent(personIdent))
+        }.fold(
+            onSuccess = { it.data ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
+            onFailure = { throw IntegrasjonException("Feil ved henting av fagsakId og aktørId fra ba-sak.", it, uri, personIdent) }
+        )
+    }
+
     fun hentMinimalRestFagsak(fagsakId: Long): RestMinimalFagsak {
         val uri = URI.create("$sakServiceUri/fagsaker/minimal/$fagsakId")
         return runCatching {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -286,6 +286,14 @@ class VurderLivshendelseTask(
         return listeMedFagsakIdOgTilknyttetAktør
     }
 
+    private fun finnBrukereBerørtAvSivilstandHendelseForIdent(
+        personIdent: String
+    ): List<RestFagsakIdOgTilknyttetAktørId> {
+        val listeMedFagsakIdOgTilknyttetAktørId = sakClient.hentFagsakerHvorPersonMottarLøpendeUtvidetEllerOrdinærBarnetrygd(personIdent)
+        secureLog.info("Aktører og fagsaker berørt av hendelse for personIdent=$personIdent: ${listeMedFagsakIdOgTilknyttetAktørId.map { "(aktørId=${it.aktørId}, fagsakId=${it.fagsakId})," }}")
+        return listeMedFagsakIdOgTilknyttetAktørId
+    }
+
     private fun opprettEllerOppdaterVurderLivshendelseOppgave(
         hendelseType: VurderLivshendelseType,
         aktørIdForOppgave: String,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -357,7 +357,7 @@ class VurderLivshendelseTask(
     }
 
     private fun hentInitiellBeskrivelseForSivilstandOppgave(personErBruker: Boolean, formatertDato: String, personIdent: String): String =
-        "${SIVILSTAND.beskrivelse}: ${if (personErBruker) "bruker" else "barn $personIdent"} er registrert gift fra $formatertDato"
+        "${SIVILSTAND.beskrivelse}: ${if (personErBruker) "bruker" else "barn $personIdent"} er registrert som gift fra $formatertDato"
 
     private fun opprettEllerOppdaterEndringISivilstandOppgave(
         endringsdato: LocalDate,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -161,13 +161,15 @@ class VurderLivshendelseTask(
                 }
                 if (featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_FINNE_BERØRTE_FAGSAKER_VED_LEESAH_HENDELSER, false)) {
                     finnBrukereBerørtAvSivilstandHendelseForIdent(personIdent).forEach {
-                        opprettEllerOppdaterEndringISivilstandOppgave(
-                            endringsdato = sivilstand.dato!!,
-                            fagsakIdForOppgave = it.fagsakId,
-                            aktørIdForOppgave = it.aktørId,
-                            personIdent = personIdent,
-                            task = task
-                        )
+                        if (sjekkOmDatoErEtterEldsteVedtaksdato(dato = sivilstand.dato!!, aktivFaksak = hentRestFagsak(it.fagsakId), personIdent = personIdent)) { // Trenger denne sjekken for å unngå "gamle" hendelser som feks kan skyldes innflytting
+                            opprettEllerOppdaterEndringISivilstandOppgave(
+                                endringsdato = sivilstand.dato!!,
+                                fagsakIdForOppgave = it.fagsakId,
+                                aktørIdForOppgave = it.aktørId,
+                                personIdent = personIdent,
+                                task = task
+                            )
+                        }
                     }
                 } else {
                     val aktivFaksak = sakClient.hentRestFagsakDeltagerListe(personIdent).filter {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -80,7 +80,7 @@ class VurderLivshendelseTask(
                     error("Har mottatt dødsfallshendelse uten dødsdato")
                 }
                 if (featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_FINNE_BERØRTE_FAGSAKER_VED_LEESAH_HENDELSER, false)) {
-                    val berørteBrukereIBaSak = finnBrukereBerørtAvHendelseForIdent(personIdent)
+                    val berørteBrukereIBaSak = finnBrukereBerørtAvDødsfallEllerUtflyttingHendelseForIdent(personIdent)
                     secureLog.info(
                         "berørteBrukereIBaSak count = ${berørteBrukereIBaSak.size}, aktørIder = ${
                         berørteBrukereIBaSak.fold("") { aktørIder, it -> aktørIder + " " + it.aktørId }
@@ -121,7 +121,7 @@ class VurderLivshendelseTask(
             }
             UTFLYTTING -> {
                 if (featureToggleService.isEnabled(FeatureToggleConfig.NY_MÅTE_Å_FINNE_BERØRTE_FAGSAKER_VED_LEESAH_HENDELSER, false)) {
-                    finnBrukereBerørtAvHendelseForIdent(personIdent).forEach {
+                    finnBrukereBerørtAvDødsfallEllerUtflyttingHendelseForIdent(personIdent).forEach {
                         if (opprettEllerOppdaterVurderLivshendelseOppgave(
                                 hendelseType = UTFLYTTING,
                                 aktørIdForOppgave = it.aktørId,
@@ -278,7 +278,7 @@ class VurderLivshendelseTask(
         }.map { Bruker(it.ident, it.fagsakId) }
     }
 
-    private fun finnBrukereBerørtAvHendelseForIdent(
+    private fun finnBrukereBerørtAvDødsfallEllerUtflyttingHendelseForIdent(
         personIdent: String
     ): List<RestFagsakIdOgTilknyttetAktørId> {
         val listeMedFagsakIdOgTilknyttetAktør = sakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -18,6 +18,7 @@ import no.nav.familie.baks.mottak.integrasjoner.PdlForeldreBarnRelasjon
 import no.nav.familie.baks.mottak.integrasjoner.PdlPersonData
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsak
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsakDeltager
+import no.nav.familie.baks.mottak.integrasjoner.RestFagsakIdOgTilknyttetAktørId
 import no.nav.familie.baks.mottak.integrasjoner.RestUtvidetBehandling
 import no.nav.familie.baks.mottak.integrasjoner.SakClient
 import no.nav.familie.baks.mottak.integrasjoner.Sivilstand
@@ -279,7 +280,7 @@ class VurderLivshendelseTask(
 
     private fun finnBrukereBerørtAvHendelseForIdent(
         personIdent: String
-    ): List<SakClient.RestFagsakIdOgTilknyttetAktørId> {
+    ): List<RestFagsakIdOgTilknyttetAktørId> {
         val listeMedFagsakIdOgTilknyttetAktør = sakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent)
         secureLog.info("Aktører og fagsaker berørt av hendelse for personIdent=$personIdent: ${listeMedFagsakIdOgTilknyttetAktør.map { "(aktørId=${it.aktørId}, fagsakId=${it.fagsakId}),"}}")
         return listeMedFagsakIdOgTilknyttetAktør

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseTask.kt
@@ -396,7 +396,7 @@ class VurderLivshendelseTask(
             is Oppgave -> {
                 log.info("Fant åpen oppgave på aktørId=$aktørIdForOppgave oppgaveId=${oppgave.id}")
                 secureLog.info("Fant åpen oppgave: $oppgave")
-                oppdaterOppgaveMedNyBeskrivelse(oppgave = oppgave, beskrivelse = "${SIVILSTAND.beskrivelse}: Bruker eller barn er registrert gift")
+                oppdaterOppgaveMedNyBeskrivelse(oppgave = oppgave, beskrivelse = "${SIVILSTAND.beskrivelse}: Bruker eller barn er registrert som gift")
                 task.metadata["oppgaveId"] = oppgave.id.toString()
                 task.metadata["info"] = "Fant åpen oppgave"
             }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9841

Ny måte å hente berørte fagsakIder+aktørIder for sivilstand-hendelser. Skal kun opprettes oppgave på sivilstand hvis person er søker og mottar løpende utvidet, eller person er barn og har løpende ordinær. I tillegg sjekker vi at datoen for endringen skjer etter eldste vedtak for personen, slik at vi slipper unna støy fra gamle hendelser som feks kan skyldes innflytting (dette ble tatt høyde for tidligere også, så gjenbruker funksjonaliteten).