### PR TITLE
Bruker dokumenttype id som postfix på eksterReferanseId for kontantstøtte og barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførKontantstøtteSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførKontantstøtteSøknadTask.kt
@@ -10,6 +10,7 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
 
@@ -53,17 +54,14 @@ class JournalførKontantstøtteSøknadTask(
             }
             journalføringService.journalførKontantstøtteSøknad(dbKontantstøtteSøknad, bokmålPdf, orginalspråkPdf)
         } catch (e: RessursException) {
-            when (e.cause) {
-                is HttpClientErrorException.Conflict -> {
-                    logger.error("409 conflict for eksternReferanseId ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
-                    SECURE_LOGGER.error(
-                        "409 conflict for eksternReferanseId ved journalføring søknad $task ${(e.cause as HttpClientErrorException.Conflict).responseBodyAsString}",
-                        e
-                    )
-                }
-
-                else -> throw e
-            }
+            if (e.httpStatus == HttpStatus.CONFLICT) {
+                // Dersom søknaden allerede er journalført får vi 409-Conflict. Vi ønsker ikke å feile tasken når dette skjer.
+                logger.error("409 conflict for eksternReferanseId ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
+                SECURE_LOGGER.error(
+                    "409 conflict for eksternReferanseId ved journalføring søknad $task ${(e.cause as HttpClientErrorException.Conflict).responseBodyAsString}",
+                    e
+                )
+            } else throw e
         } catch (e: Exception) {
             logger.error("Uventet feil ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
             SECURE_LOGGER.error("Uventet feil ved journalføring søknad $task", e)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
@@ -7,11 +7,13 @@ import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV7
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertSøknad
+import no.nav.familie.http.client.RessursException
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
 
@@ -50,12 +52,15 @@ class JournalførSøknadTask(
                 ByteArray(0)
             }
             journalføringService.journalførBarnetrygdSøknad(dbSøknad, bokmålPdf, orginalspråkPdf)
-        } catch (e: HttpClientErrorException.Conflict) {
-            log.error("409 conflict for eksternReferanseId ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
-            SECURE_LOGGER.error(
-                "409 conflict for eksternReferanseId ved journalføring søknad $task ${e.responseBodyAsString}",
-                e
-            )
+        } catch (e: RessursException) {
+            if (e.httpStatus == HttpStatus.CONFLICT) {
+                // Dersom søknaden allerede er journalført får vi 409-Conflict. Vi ønsker ikke å feile tasken når dette skjer.
+                log.error("409 conflict for eksternReferanseId ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
+                SECURE_LOGGER.error(
+                    "409 conflict for eksternReferanseId ved journalføring søknad $task ${(e.cause as HttpClientErrorException.Conflict).responseBodyAsString}",
+                    e
+                )
+            } else throw e
         } catch (e: Exception) {
             log.error("Uventet feil ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
             SECURE_LOGGER.error("Uventet feil ved journalføring søknad $task", e)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
@@ -13,7 +13,6 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
 
@@ -53,14 +52,18 @@ class JournalførSøknadTask(
             }
             journalføringService.journalførBarnetrygdSøknad(dbSøknad, bokmålPdf, orginalspråkPdf)
         } catch (e: RessursException) {
-            if (e.httpStatus == HttpStatus.CONFLICT) {
-                // Dersom søknaden allerede er journalført får vi 409-Conflict. Vi ønsker ikke å feile tasken når dette skjer.
-                log.error("409 conflict for eksternReferanseId ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
-                SECURE_LOGGER.error(
-                    "409 conflict for eksternReferanseId ved journalføring søknad $task ${(e.cause as HttpClientErrorException.Conflict).responseBodyAsString}",
-                    e
-                )
-            } else throw e
+            when (e.cause) {
+                is HttpClientErrorException.Conflict -> {
+                    // Dersom søknaden allerede er journalført får vi 409-Conflict. Vi ønsker ikke å feile tasken når dette skjer.
+                    log.error("409 conflict for eksternReferanseId ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
+                    SECURE_LOGGER.error(
+                        "409 conflict for eksternReferanseId ved journalføring søknad $task ${(e.cause as HttpClientErrorException.Conflict).responseBodyAsString}",
+                        e
+                    )
+                }
+
+                else -> throw e
+            }
         } catch (e: Exception) {
             log.error("Uventet feil ved journalføring av søknad. taskId=${task.id}. Se task eller securelog")
             SECURE_LOGGER.error("Uventet feil ved journalføring søknad $task", e)

--- a/src/test/kotlin/no/nav/familie/baks/mottak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/config/ClientMocks.kt
@@ -12,6 +12,8 @@ import no.nav.familie.baks.mottak.integrasjoner.Journalstatus
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveClient
 import no.nav.familie.baks.mottak.integrasjoner.PdfClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.http.client.RessursException
+import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import org.springframework.context.annotation.Bean
@@ -56,7 +58,11 @@ class ClientMocks {
         every {
             mockDokarkivClientConflict.arkiver(any())
         } answers {
-            throw HttpClientErrorException.Conflict.create(HttpStatus.CONFLICT, null, null, null, null)
+            throw RessursException(
+                Ressurs(status = Ressurs.Status.FEILET, data = null, melding = "", stacktrace = ""),
+                HttpClientErrorException.Conflict.create(HttpStatus.CONFLICT, null, null, null, null),
+                HttpStatus.CONFLICT
+            )
         }
         return mockDokarkivClientConflict
     }


### PR DESCRIPTION
Sørger for at feltet `eksternReferanseId` alltid blir unikt ved arkivering/journalføring av kontantstøtte og barnetrygd søknader. Tidligere brukte både barnetrygd og kontantstøtte kun id'en til søknaden i db som `eksternReferanseId`, men dette førte til overlapp på id'er, og vi fikk 409 Conflict i kall mot Dokarkiv når vi forsøkte å journalføre kontantstøtte søknader.

`eksternRefernaseId` er nå søknadsId'en som tidligere, men denne gangen postfixet med dokumentId'en til dokumenttypen.