### PR TITLE
Opprette journalføringsoppgave for kontantstøttesøknader 

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/FeatureToggleConfig.kt
@@ -87,7 +87,10 @@ class FeatureToggleConfig(
     }
 
     companion object {
-        const val NY_MÅTE_Å_FINNE_BERØRTE_FAGSAKER_VED_LEESAH_HENDELSER = "familie-ba-mottak.ny-metode-finne-berorte-fagsaker-ved-leesah-hendelse"
+        const val NY_MÅTE_Å_FINNE_BERØRTE_FAGSAKER_VED_LEESAH_HENDELSER =
+            "familie-ba-mottak.ny-metode-finne-berorte-fagsaker-ved-leesah-hendelse"
+        const val OPPRETTE_JOURNALFØRINGSOPPGAVE_KONTANTSTØTTE =
+            "familie-baks-mottak.opprett-journalforingsoppgave-kontantstotte"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalhendelseService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.baks.mottak.integrasjoner.Journalpost
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalposttype
 import no.nav.familie.baks.mottak.integrasjoner.Journalstatus
+import no.nav.familie.baks.mottak.task.JournalhendelseKontantstøtteRutingTask
 import no.nav.familie.baks.mottak.task.JournalhendelseRutingTask
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.log.IdUtils
@@ -180,8 +181,12 @@ class JournalhendelseService(
         GYLDIGE_JOURNALPOST_TEMAER.contains(journalpost.tema) && journalpost.journalposttype == Journalposttype.I
 
     private fun opprettJournalhendelseRutingTask(journalpost: Journalpost) {
+        val taskType = when (journalpost.tema) {
+            Tema.BAR.name -> JournalhendelseRutingTask.TASK_STEP_TYPE
+            else -> JournalhendelseKontantstøtteRutingTask.TASK_STEP_TYPE
+        }
         Task(
-            type = JournalhendelseRutingTask.TASK_STEP_TYPE,
+            type = taskType,
             payload = journalpost.kanal!!,
             properties = opprettMetadata(journalpost)
         ).apply {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalhendelseService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalposttype
 import no.nav.familie.baks.mottak.integrasjoner.Journalstatus
 import no.nav.familie.baks.mottak.task.JournalhendelseRutingTask
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.domene.Task
@@ -31,9 +32,13 @@ class JournalhendelseService(
     val hendelsesloggRepository: HendelsesloggRepository
 ) {
 
-    val kanalCounter = mutableMapOf<String, Counter>()
-    val skannetOrdinæreSøknaderCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skan.ny.ordinaer.soknad")
-    val skannetUtvidedeSøknaderCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.kanal.skan.ny.utvidet.soknad")
+    val barnetrygdKanalCounter = mutableMapOf<String, Counter>()
+    val kontantstøtteKanalCounter = mutableMapOf<String, Counter>()
+    val skannetOrdinærBarnetrygdSøknadCounter: Counter =
+        Metrics.counter("barnetrygd.journalhendelse.kanal.skan.ny.ordinaer.soknad")
+    val skannetUtvidetBarnetrygdSøknadCounter: Counter =
+        Metrics.counter("barnetrygd.journalhendelse.kanal.skan.ny.utvidet.soknad")
+    val skannetKontantstøtteSøknadCounter = Metrics.counter("kontantstotte.journalhendelse.kanal.skan.ny.soknad")
     val ignorerteCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.ignorerte")
     val feilCounter: Counter = Metrics.counter("barnetrygd.journalhendelse.feilet")
     val logger: Logger = LoggerFactory.getLogger(JournalhendelseService::class.java)
@@ -49,7 +54,11 @@ class JournalhendelseService(
             MDC.put(MDCConstants.MDC_CALL_ID, callId)
 
             if (erGyldigHendelsetype(hendelseRecord)) {
-                if (hendelsesloggRepository.existsByHendelseIdAndConsumer(hendelseRecord.hendelsesId.toString(), CONSUMER_JOURNAL)) {
+                if (hendelsesloggRepository.existsByHendelseIdAndConsumer(
+                        hendelseRecord.hendelsesId.toString(),
+                        CONSUMER_JOURNAL
+                    )
+                ) {
                     ack.acknowledge()
                     return
                 }
@@ -95,7 +104,7 @@ class JournalhendelseService(
 
     private fun erGyldigHendelsetype(hendelseRecord: JournalfoeringHendelseRecord): Boolean {
         return GYLDIGE_HENDELSE_TYPER.contains(hendelseRecord.hendelsesType.toString()) &&
-            (hendelseRecord.temaNytt != null && hendelseRecord.temaNytt.toString() == "BAR")
+            (hendelseRecord.temaNytt != null && GYLDIGE_JOURNALPOST_TEMAER.contains(hendelseRecord.temaNytt.toString()))
     }
 
     fun behandleJournalhendelse(hendelseRecord: JournalfoeringHendelseRecord) {
@@ -116,10 +125,11 @@ class JournalhendelseService(
 
                         else -> {
                             logger.info("Ny journalhendelse med journalpostId=$journalpostId med status MOTTATT og kanal ${journalpost.kanal}")
-                            incrementKanalCounter(journalpost.kanal.toString())
+                            incrementKanalCounter(journalpost)
                         }
                     }
                 }
+
                 else -> {
                     logger.debug("Ignorer journalhendelse hvor journalpost=$journalpostId har status ${journalpost.journalstatus}")
                     ignorerteCounter.count()
@@ -130,30 +140,44 @@ class JournalhendelseService(
 
     private fun behandleNavnoHendelser(journalpost: Journalpost) {
         opprettJournalhendelseRutingTask(journalpost)
-        incrementKanalCounter(journalpost.kanal!!)
+        incrementKanalCounter(journalpost)
     }
 
     private fun behandleSkanningHendelser(journalpost: Journalpost) {
         logger.info("Ny Journalhendelse med [journalpostId=${journalpost.journalpostId}, status=${journalpost.journalstatus}, tema=${journalpost.tema}, kanal=${journalpost.kanal}]")
-        val erOrdinærSønad = journalpost.dokumenter?.find { it.brevkode == "NAV 33-00.07" } != null
-        val erUtvidetSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 33-00.09" } != null
+        val erOrdinærBarnetrygdSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 33-00.07" } != null
+        val erUtvidetBarnetrygdSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 33-00.09" } != null
+        val erKontantstøtteSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 34-00.08" } != null
 
         opprettJournalhendelseRutingTask(journalpost)
 
-        if (erOrdinærSønad) skannetOrdinæreSøknaderCounter.increment()
-        if (erUtvidetSøknad) skannetUtvidedeSøknaderCounter.increment()
-        incrementKanalCounter(journalpost.kanal!!)
+        if (erOrdinærBarnetrygdSøknad) skannetOrdinærBarnetrygdSøknadCounter.increment()
+        if (erUtvidetBarnetrygdSøknad) skannetUtvidetBarnetrygdSøknadCounter.increment()
+        if (erKontantstøtteSøknad) skannetKontantstøtteSøknadCounter.increment()
+
+        incrementKanalCounter(journalpost)
     }
 
-    private fun incrementKanalCounter(kanal: String) {
-        if (!kanalCounter.containsKey(kanal)) {
-            kanalCounter[kanal] = Metrics.counter("barnetrygd.journalhendelse.mottatt", "kanal", kanal)
+    private fun incrementKanalCounter(
+        journalpost: Journalpost
+    ) {
+        val (søknadKanalCounter, counterName) = getKanalCounter(journalpost)
+        val kanal = journalpost.kanal!!
+        if (!søknadKanalCounter.containsKey(kanal)) {
+            søknadKanalCounter[kanal] = Metrics.counter(counterName, "kanal", kanal)
         }
-        kanalCounter[kanal]!!.increment()
+        søknadKanalCounter[kanal]!!.increment()
     }
+
+    private fun getKanalCounter(journalpost: Journalpost) =
+        if (journalpost.tema == Tema.BAR.name) {
+            Pair(barnetrygdKanalCounter, "barnetrygd.journalhendelse.mottatt")
+        } else {
+            Pair(kontantstøtteKanalCounter, "kontantstotte.journalhendelse.mottatt")
+        }
 
     private fun skalBehandleJournalpost(journalpost: Journalpost) =
-        journalpost.tema == "BAR" && journalpost.journalposttype == Journalposttype.I
+        GYLDIGE_JOURNALPOST_TEMAER.contains(journalpost.tema) && journalpost.journalposttype == Journalposttype.I
 
     private fun opprettJournalhendelseRutingTask(journalpost: Journalpost) {
         Task(
@@ -180,6 +204,7 @@ class JournalhendelseService(
     companion object {
 
         private val GYLDIGE_HENDELSE_TYPER = arrayOf("JournalpostMottatt", "TemaEndret")
+        private val GYLDIGE_JOURNALPOST_TEMAER = listOf(Tema.BAR.name, Tema.KON.name)
         private val CONSUMER_JOURNAL = HendelseConsumer.JOURNAL_AIVEN
     }
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/AbstractOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/AbstractOppgaveMapper.kt
@@ -9,6 +9,7 @@ import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
 import java.util.*
 
 abstract class AbstractOppgaveMapper(
@@ -139,4 +140,13 @@ interface IOppgaveMapper {
     fun støtterTema(tema: Tema) = this.tema == tema
 }
 
-fun List<IOppgaveMapper>.tilMapperForTema(tema: Tema): IOppgaveMapper = this.first { it.støtterTema(tema) }
+@Service
+class OppgaveMapperService(val oppgaveMappers: Collection<IOppgaveMapper>) {
+    fun tilOpprettOppgaveRequest(
+        oppgavetype: Oppgavetype,
+        journalpost: Journalpost,
+        beskrivelse: String? = null
+    ): OpprettOppgaveRequest =
+        oppgaveMappers.first { it.støtterTema(Tema.valueOf(journalpost.tema!!)) }
+            .tilOpprettOppgaveRequest(oppgavetype, journalpost, beskrivelse)
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
+import org.springframework.stereotype.Service
+
+@Service
+class BarnetrygdOppgaveMapper(hentEnhetClient: HentEnhetClient, pdlClient: PdlClient) :
+    AbstractOppgaveMapper(hentEnhetClient, pdlClient) {
+
+    override val tema: Tema = Tema.BAR
+
+    // Behandlingstema og behandlingstype settes basert på regelsettet som er dokumentert nederst her: https://confluence.adeo.no/display/TFA/Mottak+av+dokumenter
+    override fun hentBehandlingstema(journalpost: Journalpost): String? {
+        return when {
+            erEØS(journalpost) -> Behandlingstema.BarnetrygdEØS.value
+            hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> null
+            else -> Behandlingstema.OrdinærBarnetrygd.value
+        }
+    }
+
+    override fun hentBehandlingstype(journalpost: Journalpost): String? {
+        return when {
+            hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> Behandlingstype.Utland.value
+            else -> null
+        }
+    }
+
+    private fun hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost: Journalpost) =
+        // Brevkode "NAV 33-00.15" representerer dokumentet "Norsk sokkel - Årlig differanseutbetaling av barnetrygd"
+        journalpost.dokumenter!!.firstOrNull { it.brevkode != null }?.brevkode == "NAV 33-00.15"
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
@@ -12,7 +12,7 @@ import java.time.YearMonth
 @Service
 class InfotrygdKontantstøtteClient(
     @Qualifier("clientCredentials") restOperations: RestOperations,
-    @Value("FAMILIE_KS_INFOTRYGD_API_URL") private val clientUri: URI,
+    @Value("\${FAMILIE_KS_INFOTRYGD_API_URL}/api") private val clientUri: URI,
     private val environment: Environment
 ) :
     AbstractRestClient(restOperations, "familie-ks-infotrygd") {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestOperations
+import org.springframework.web.client.postForObject
 import java.net.URI
 import java.time.YearMonth
 
@@ -21,7 +22,12 @@ class InfotrygdKontantstøtteClient(
         barnasIdenter: List<String>
     ): Boolean {
         return infotrygdResponseFra(
-            request = postForEntity(uri("harLøpendeKontantstotteIInfotrygd"), InnsynRequest(barnasIdenter)),
+            request = {
+                operations.postForObject(
+                    uri("harLøpendeKontantstotteIInfotrygd"),
+                    InnsynRequest(barnasIdenter)
+                )
+            },
             onFailure = { ex ->
                 IntegrasjonException(
                     "Feil ved søk etter stønad i infotrygd.",

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
+import com.fasterxml.jackson.annotation.JsonValue
 import no.nav.familie.http.client.AbstractRestClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -81,4 +82,4 @@ data class BarnDto(
     val fnr: Foedselsnummer
 )
 
-data class Foedselsnummer(val asString: String)
+data class Foedselsnummer(@get:JsonValue val asString: String)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdKontantstøtteClient.kt
@@ -1,0 +1,84 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import no.nav.familie.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+import java.net.URI
+import java.time.YearMonth
+
+@Service
+class InfotrygdKontantstøtteClient(
+    @Qualifier("clientCredentials") restOperations: RestOperations,
+    @Value("FAMILIE_KS_INFOTRYGD_API_URL") private val clientUri: URI,
+    private val environment: Environment
+) :
+    AbstractRestClient(restOperations, "familie-ks-infotrygd") {
+    fun harKontantstøtteIInfotrygd(
+        barnasIdenter: List<String>
+    ): Boolean {
+        return infotrygdResponseFra(
+            request = postForEntity(uri("harLøpendeKontantstotteIInfotrygd"), InnsynRequest(barnasIdenter)),
+            onFailure = { ex ->
+                IntegrasjonException(
+                    "Feil ved søk etter stønad i infotrygd.",
+                    ex,
+                    uri("harLøpendeKontantstotteIInfotrygd")
+                )
+            },
+            e2eResponse = false
+        )
+    }
+
+    fun hentPerioderMedKontantstøtteIInfotrygd(
+        barnasIdenter: List<String>
+    ): InnsynResponse {
+        return infotrygdResponseFra(
+            request = postForEntity(uri("hentPerioderMedKontantstøtteIInfotrygd"), InnsynRequest(barnasIdenter)),
+            onFailure = { ex ->
+                IntegrasjonException(
+                    "Feil ved uthenting av saker fra infotrygd.",
+                    ex,
+                    uri("hentPerioderMedKontantstøtteIInfotrygd")
+                )
+            },
+            e2eResponse = InnsynResponse(emptyList())
+        )
+    }
+
+    private fun <T> infotrygdResponseFra(
+        request: () -> T,
+        onFailure: (Throwable) -> RuntimeException,
+        e2eResponse: T
+    ): T = if (environment.activeProfiles.contains("e2e")) {
+        e2eResponse
+    } else {
+        runCatching(request).getOrElse { throw onFailure(it) }
+    }
+
+    private fun uri(endepunkt: String) = URI.create("$clientUri/$endepunkt")
+}
+
+data class InnsynRequest(
+    val barn: List<String>
+)
+
+data class InnsynResponse(
+    val data: List<StonadDto>
+)
+
+data class StonadDto(
+    val fnr: Foedselsnummer,
+    val fom: YearMonth?,
+    val tom: YearMonth?,
+    val belop: Int?,
+    val barn: List<BarnDto>
+)
+
+data class BarnDto(
+    val fnr: Foedselsnummer
+)
+
+data class Foedselsnummer(val asString: String)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
+import org.springframework.stereotype.Service
+
+@Service
+class KontantstøtteOppgaveMapper(
+    hentEnhetClient: HentEnhetClient,
+    pdlClient: PdlClient
+) : AbstractOppgaveMapper(hentEnhetClient, pdlClient) {
+
+    override val tema: Tema = Tema.KON
+
+    override fun hentBehandlingstema(journalpost: Journalpost): String? {
+        return null
+    }
+
+    override fun hentBehandlingstype(journalpost: Journalpost): String? {
+        return when {
+            erEØS(journalpost) -> Behandlingstype.EØS.value
+            else -> Behandlingstype.NASJONAL.value
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClient.kt
@@ -30,7 +30,7 @@ private val logger = LoggerFactory.getLogger(OppgaveClient::class.java)
 class OppgaveClient @Autowired constructor(
     @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
     @Qualifier("clientCredentials") restOperations: RestOperations,
-    private val oppgaveMappers: List<IOppgaveMapper>
+    private val oppgaveMapperService: OppgaveMapperService
 ) : AbstractRestClient(restOperations, "integrasjon") {
 
     val secureLog: Logger = LoggerFactory.getLogger("secureLogger")
@@ -41,7 +41,7 @@ class OppgaveClient @Autowired constructor(
     ): OppgaveResponse {
         logger.info("Oppretter journalføringsoppgave for ${if (journalpost.kanal == "NAV_NO") "digital søknad" else "papirsøknad"}")
         val uri = URI.create("$integrasjonUri/oppgave/opprett")
-        val request = oppgaveMapperForTema(journalpost).tilOpprettOppgaveRequest(
+        val request = oppgaveMapperService.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpost,
             beskrivelse
@@ -54,7 +54,7 @@ class OppgaveClient @Autowired constructor(
     fun opprettBehandleSakOppgave(journalpost: Journalpost, beskrivelse: String? = null): OppgaveResponse {
         logger.info("Oppretter \"Behandle sak\"-oppgave for digital søknad")
         val uri = URI.create("$integrasjonUri/oppgave/opprett")
-        val request = oppgaveMapperForTema(journalpost).tilOpprettOppgaveRequest(
+        val request = oppgaveMapperService.tilOpprettOppgaveRequest(
             Oppgavetype.BehandleSak,
             journalpost,
             beskrivelse
@@ -62,9 +62,6 @@ class OppgaveClient @Autowired constructor(
 
         return responseFraOpprettOppgave(uri, request)
     }
-
-    private fun oppgaveMapperForTema(journalpost: Journalpost) =
-        oppgaveMappers.tilMapperForTema(Tema.valueOf(journalpost.tema!!))
 
     @Retryable(
         value = [RuntimeException::class],

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapper.kt
@@ -28,8 +28,12 @@ class OppgaveMapper(
         beskrivelse: String? = null
     ): OpprettOppgaveRequest {
         val ident = tilOppgaveIdent(journalpost, oppgavetype)
-        val tema = journalpost.tema?.let { Tema.valueOf(it) }
-            ?: throw RuntimeException("Feil ved mapping til OpprettOppgaveRequest. Tema for journalpost er tomt eller ugyldig: ${journalpost.tema}")
+        val tema = runCatching { Tema.valueOf(journalpost.tema!!) }.getOrElse { exception ->
+            throw RuntimeException(
+                "Feil ved mapping til OpprettOppgaveRequest. Tema for journalpost er tomt eller ugyldig: ${journalpost.tema}",
+                exception
+            )
+        }
         return OpprettOppgaveRequest(
             ident = ident,
             saksId = journalpost.sak?.fagsakId,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapper.kt
@@ -28,16 +28,18 @@ class OppgaveMapper(
         beskrivelse: String? = null
     ): OpprettOppgaveRequest {
         val ident = tilOppgaveIdent(journalpost, oppgavetype)
+        val tema = journalpost.tema?.let { Tema.valueOf(it) }
+            ?: throw RuntimeException("Feil ved mapping til OpprettOppgaveRequest. Tema for journalpost er tomt eller ugyldig: ${journalpost.tema}")
         return OpprettOppgaveRequest(
             ident = ident,
             saksId = journalpost.sak?.fagsakId,
             journalpostId = journalpost.journalpostId,
-            tema = Tema.BAR,
+            tema = tema,
             oppgavetype = oppgavetype,
             fristFerdigstillelse = fristFerdigstillelse(),
             beskrivelse = tilBeskrivelse(journalpost, beskrivelse),
             enhetsnummer = utledEnhetsnummer(journalpost),
-            behandlingstema = hentBehandlingstema(journalpost),
+            behandlingstema = hentBehandlingstema(journalpost, tema),
             behandlingstype = hentBehandlingstype(journalpost)
         )
     }
@@ -55,13 +57,22 @@ class OppgaveMapper(
 
         return when (journalpost.bruker?.type) {
             BrukerIdType.FNR -> {
-                hentAktørIdFraPdl(journalpost.bruker.id.trim())?.let { OppgaveIdentV2(ident = it, gruppe = IdentGruppe.AKTOERID) }
+                hentAktørIdFraPdl(journalpost.bruker.id.trim())?.let {
+                    OppgaveIdentV2(
+                        ident = it,
+                        gruppe = IdentGruppe.AKTOERID
+                    )
+                }
                     ?: if (oppgavetype == Oppgavetype.BehandleSak) {
-                        throw IntegrasjonException(msg = "Fant ikke aktørId på person i PDL", ident = journalpost.bruker.id)
+                        throw IntegrasjonException(
+                            msg = "Fant ikke aktørId på person i PDL",
+                            ident = journalpost.bruker.id
+                        )
                     } else {
                         null
                     }
             }
+
             BrukerIdType.ORGNR -> {
                 if (erOrgnr(journalpost.bruker.id.trim())) {
                     OppgaveIdentV2(ident = journalpost.bruker.id.trim(), gruppe = IdentGruppe.ORGNR)
@@ -69,6 +80,7 @@ class OppgaveMapper(
                     null
                 }
             }
+
             BrukerIdType.AKTOERID -> OppgaveIdentV2(ident = journalpost.bruker.id.trim(), gruppe = IdentGruppe.AKTOERID)
             else -> null
         }
@@ -84,16 +96,23 @@ class OppgaveMapper(
         return "${journalpost.hentHovedDokumentTittel().orEmpty()} $bindestrek ${beskrivelse.orEmpty()}".trim()
     }
 
-    private fun hentBehandlingstema(journalpost: Journalpost): String? {
+    private fun hentBehandlingstema(journalpost: Journalpost, tema: Tema): String? {
         if (journalpost.dokumenter.isNullOrEmpty()) error("Journalpost ${journalpost.journalpostId} mangler dokumenter")
 
         if (journalpost.bruker?.type == BrukerIdType.FNR && erDnummer(journalpost.bruker.id)) {
-            return Behandlingstema.BarnetrygdEØS.value
+            return when (tema) {
+                Tema.BAR -> Behandlingstema.BarnetrygdEØS.value
+                else -> Behandlingstema.KontantstøtteEØS.value
+            }
         }
 
         return when (journalpost.dokumenter.firstOrNull { it.brevkode != null }?.brevkode) {
+            // Tilleggsskjema ved krav om utbetaling av barnetrygd og/eller kontantstøtte på grunnlag av regler om eksport etter EØS-avtalen
             "NAV 33-00.15" -> null
-            else -> Behandlingstema.OrdinærBarnetrygd.value
+            else -> when (tema) {
+                Tema.BAR -> Behandlingstema.OrdinærBarnetrygd.value
+                else -> Behandlingstema.Kontantstøtte.value
+            }
         }
     }
 
@@ -118,7 +137,8 @@ class OppgaveMapper(
 
     private fun hentAktørIdFraPdl(brukerId: String): String? {
         return try {
-            pdlClient.hentIdenter(brukerId).filter { it.gruppe == Identgruppe.AKTORID.name && !it.historisk }.lastOrNull()?.ident
+            pdlClient.hentIdenter(brukerId).filter { it.gruppe == Identgruppe.AKTORID.name && !it.historisk }
+                .lastOrNull()?.ident
         } catch (e: IntegrasjonException) {
             null
         }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -2,7 +2,11 @@ package no.nav.familie.baks.mottak.task
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
+import no.nav.familie.baks.mottak.integrasjoner.Identgruppe
+import no.nav.familie.baks.mottak.integrasjoner.InfotrygdKontantstøtteClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.baks.mottak.integrasjoner.StonadDto
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -10,6 +14,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.YearMonth
 
 @Service
 @TaskStepBeskrivelse(
@@ -18,6 +23,7 @@ import org.springframework.stereotype.Service
 )
 class JournalhendelseKontantstøtteRutingTask(
     private val pdlClient: PdlClient,
+    private val infotrygdKontantstøtteClient: InfotrygdKontantstøtteClient,
     private val taskService: TaskService
 ) : AsyncTaskStep {
 
@@ -27,28 +33,18 @@ class JournalhendelseKontantstøtteRutingTask(
     override fun doTask(task: Task) {
         val brukersIdent = task.metadata["personIdent"] as String?
 
-        val (ksSak, infotrygdSak) = brukersIdent?.run { søkEtterSakIKsSakOgInfotrygd(this) } ?: Pair(null, null)
+        val harLøpendeSakIInfotrygd = brukersIdent?.run { søkEtterSakIInfotrygd(this) } ?: false
 
         val sakssystemMarkering = when {
-            ksSak.finnes() && infotrygdSak.finnes() -> {
-                incrementSakssystemMarkering("Begge")
-                "Bruker har sak i både Infotrygd og KS-sak"
-            }
-
-            ksSak.finnes() -> {
-                incrementSakssystemMarkering("KS_SAK")
-                "${ksSak!!.part} har sak i BA-sak"
-            }
-
-            infotrygdSak.finnes() -> {
+            harLøpendeSakIInfotrygd -> {
                 incrementSakssystemMarkering("Infotrygd")
-                "${infotrygdSak!!.part} har sak i Infotrygd"
+                "Et eller flere av barna har løpende sak i Infotrygd"
             }
 
             else -> {
                 incrementSakssystemMarkering("Ingen")
                 ""
-            } // trenger ingen form for markering. Kan løses av begge systemer
+            }
         }
 
         Task(
@@ -66,55 +62,32 @@ class JournalhendelseKontantstøtteRutingTask(
         sakssystemMarkeringCounter[saksystem]!!.increment()
     }
 
-    private fun søkEtterSakIKsSakOgInfotrygd(brukersIdent: String): Pair<Sakspart?, Sakspart?> {
-        return Pair(null, null)
-        // TODO: Hent eventuelle saker fra infotrygd og kontantstøtte
-//        val brukersIdenter = try {
-//            pdlClient.hentIdenter(brukersIdent).filter { it.gruppe == Identgruppe.FOLKEREGISTERIDENT.name }
-//                .map { it.ident }
-//        } catch (e: IntegrasjonException) {
-//            return Pair(null, null)
-//        }
-//        val barnasIdenter = pdlClient.hentPersonMedRelasjoner(brukersIdent).forelderBarnRelasjoner
-//            .filter { it.relatertPersonsRolle == FORELDERBARNRELASJONROLLE.BARN }
-//            .map { it.relatertPersonsIdent }
-//            .filterNotNull()
-//        val alleBarnasIdenter = barnasIdenter.flatMap { pdlClient.hentIdenter(it) }
-//            .filter { it.gruppe == Identgruppe.FOLKEREGISTERIDENT.name }
-//            .map { it.ident }
-//
-//        return Pair(
-//            first = baSakClient.hentRestFagsakDeltagerListe(brukersIdent, barnasIdenter).sakspart(baSakClient),
-//            second = infotrygdBarnetrygdClient.hentLøpendeUtbetalinger(brukersIdenter, alleBarnasIdenter).sakspart
-//                ?: infotrygdBarnetrygdClient.hentSaker(brukersIdenter, alleBarnasIdenter).sakspart
-//        )
+    private fun søkEtterSakIInfotrygd(brukersIdent: String): Boolean {
+        val barnasIdenter = pdlClient.hentPersonMedRelasjoner(brukersIdent).forelderBarnRelasjoner
+            .filter { it.relatertPersonsRolle == FORELDERBARNRELASJONROLLE.BARN }
+            .map { it.relatertPersonsIdent }
+            .filterNotNull()
+        val alleBarnasIdenter = barnasIdenter.flatMap { pdlClient.hentIdenter(it) }
+            .filter { it.gruppe == Identgruppe.FOLKEREGISTERIDENT.name }
+            .map { it.ident }
+
+        return if (infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(alleBarnasIdenter)) {
+            infotrygdKontantstøtteClient.hentPerioderMedKontantstøtteIInfotrygd(alleBarnasIdenter).data.harPågåendeSak()
+        } else false
     }
 
-    fun Sakspart?.finnes(): Boolean = this != null
-
     companion object {
-
         const val TASK_STEP_TYPE = "journalhendelseKontantstøtteRuting"
     }
 }
 
-// TODO: Fjern eller legg inn tilsvarende når vi får lagt inn KSSakKlient
-// private fun List<RestFagsakDeltager>.sakspart(baSakClient: BaSakClient): Sakspart? = when {
-//    any { it.rolle == FORELDER && it.harPågåendeSak(baSakClient) } -> Sakspart.SØKER
-//    any { it.rolle == BARN && it.harPågåendeSak(baSakClient) } -> Sakspart.ANNEN
-//    else -> null
-// }
-//
-// private fun RestFagsakDeltager.harPågåendeSak(baSakClient: BaSakClient): Boolean {
-//    return when (fagsakStatus) {
-//        OPPRETTET, LØPENDE -> true
-//        AVSLUTTET -> !sisteBehandlingHenlagtEllerTekniskOpphør(baSakClient.hentRestFagsak(fagsakId))
-//    }
-// }
-//
-// private fun sisteBehandlingHenlagtEllerTekniskOpphør(fagsak: RestFagsak): Boolean {
-//    val sisteBehandling = fagsak.behandlinger
-//        .sortedBy { it.opprettetTidspunkt }
-//        .findLast { it.steg == "BEHANDLING_AVSLUTTET" } ?: return false
-//    return sisteBehandling.type == "TEKNISK_OPPHØR" || sisteBehandling.resultat.startsWith("HENLAGT")
-// }
+private fun List<StonadDto>.harPågåendeSak(): Boolean = any { it.erPågåendeSak() }
+
+private fun StonadDto.erPågåendeSak(): Boolean {
+    return when {
+        tom == null -> true
+        tom.isBefore(YearMonth.now()) -> false
+        tom.isAfter(YearMonth.now()) -> true
+        else -> true
+    }
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -1,0 +1,120 @@
+package no.nav.familie.baks.mottak.task
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Metrics
+import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = JournalhendelseKontantstøtteRutingTask.TASK_STEP_TYPE,
+    beskrivelse = "Håndterer ruting og markering av sakssystem"
+)
+class JournalhendelseKontantstøtteRutingTask(
+    private val pdlClient: PdlClient,
+    private val taskService: TaskService
+) : AsyncTaskStep {
+
+    val log: Logger = LoggerFactory.getLogger(JournalhendelseKontantstøtteRutingTask::class.java)
+    val sakssystemMarkeringCounter = mutableMapOf<String, Counter>()
+
+    override fun doTask(task: Task) {
+        val brukersIdent = task.metadata["personIdent"] as String?
+
+        val (ksSak, infotrygdSak) = brukersIdent?.run { søkEtterSakIKsSakOgInfotrygd(this) } ?: Pair(null, null)
+
+        val sakssystemMarkering = when {
+            ksSak.finnes() && infotrygdSak.finnes() -> {
+                incrementSakssystemMarkering("Begge")
+                "Bruker har sak i både Infotrygd og KS-sak"
+            }
+
+            ksSak.finnes() -> {
+                incrementSakssystemMarkering("KS_SAK")
+                "${ksSak!!.part} har sak i BA-sak"
+            }
+
+            infotrygdSak.finnes() -> {
+                incrementSakssystemMarkering("Infotrygd")
+                "${infotrygdSak!!.part} har sak i Infotrygd"
+            }
+
+            else -> {
+                incrementSakssystemMarkering("Ingen")
+                ""
+            } // trenger ingen form for markering. Kan løses av begge systemer
+        }
+
+        Task(
+            type = OpprettJournalføringOppgaveTask.TASK_STEP_TYPE,
+            payload = sakssystemMarkering,
+            properties = task.metadata
+        ).apply { taskService.save(this) }
+    }
+
+    private fun incrementSakssystemMarkering(saksystem: String) {
+        if (!sakssystemMarkeringCounter.containsKey(saksystem)) {
+            sakssystemMarkeringCounter[saksystem] =
+                Metrics.counter("kontantstotte.ruting.saksystem", "saksystem", saksystem)
+        }
+        sakssystemMarkeringCounter[saksystem]!!.increment()
+    }
+
+    private fun søkEtterSakIKsSakOgInfotrygd(brukersIdent: String): Pair<Sakspart?, Sakspart?> {
+        return Pair(null, null)
+        // TODO: Hent eventuelle saker fra infotrygd og kontantstøtte
+//        val brukersIdenter = try {
+//            pdlClient.hentIdenter(brukersIdent).filter { it.gruppe == Identgruppe.FOLKEREGISTERIDENT.name }
+//                .map { it.ident }
+//        } catch (e: IntegrasjonException) {
+//            return Pair(null, null)
+//        }
+//        val barnasIdenter = pdlClient.hentPersonMedRelasjoner(brukersIdent).forelderBarnRelasjoner
+//            .filter { it.relatertPersonsRolle == FORELDERBARNRELASJONROLLE.BARN }
+//            .map { it.relatertPersonsIdent }
+//            .filterNotNull()
+//        val alleBarnasIdenter = barnasIdenter.flatMap { pdlClient.hentIdenter(it) }
+//            .filter { it.gruppe == Identgruppe.FOLKEREGISTERIDENT.name }
+//            .map { it.ident }
+//
+//        return Pair(
+//            first = baSakClient.hentRestFagsakDeltagerListe(brukersIdent, barnasIdenter).sakspart(baSakClient),
+//            second = infotrygdBarnetrygdClient.hentLøpendeUtbetalinger(brukersIdenter, alleBarnasIdenter).sakspart
+//                ?: infotrygdBarnetrygdClient.hentSaker(brukersIdenter, alleBarnasIdenter).sakspart
+//        )
+    }
+
+    fun Sakspart?.finnes(): Boolean = this != null
+
+    companion object {
+
+        const val TASK_STEP_TYPE = "journalhendelseKontantstøtteRuting"
+    }
+}
+
+// TODO: Fjern eller legg inn tilsvarende når vi får lagt inn KSSakKlient
+// private fun List<RestFagsakDeltager>.sakspart(baSakClient: BaSakClient): Sakspart? = when {
+//    any { it.rolle == FORELDER && it.harPågåendeSak(baSakClient) } -> Sakspart.SØKER
+//    any { it.rolle == BARN && it.harPågåendeSak(baSakClient) } -> Sakspart.ANNEN
+//    else -> null
+// }
+//
+// private fun RestFagsakDeltager.harPågåendeSak(baSakClient: BaSakClient): Boolean {
+//    return when (fagsakStatus) {
+//        OPPRETTET, LØPENDE -> true
+//        AVSLUTTET -> !sisteBehandlingHenlagtEllerTekniskOpphør(baSakClient.hentRestFagsak(fagsakId))
+//    }
+// }
+//
+// private fun sisteBehandlingHenlagtEllerTekniskOpphør(fagsak: RestFagsak): Boolean {
+//    val sisteBehandling = fagsak.behandlinger
+//        .sortedBy { it.opprettetTidspunkt }
+//        .findLast { it.steg == "BEHANDLING_AVSLUTTET" } ?: return false
+//    return sisteBehandling.type == "TEKNISK_OPPHØR" || sisteBehandling.resultat.startsWith("HENLAGT")
+// }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -73,7 +73,9 @@ class JournalhendelseKontantstøtteRutingTask(
 
         return if (infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(alleBarnasIdenter)) {
             infotrygdKontantstøtteClient.hentPerioderMedKontantstøtteIInfotrygd(alleBarnasIdenter).data.harPågåendeSak()
-        } else false
+        } else {
+            false
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -85,7 +85,6 @@ class JournalhendelseKontantstøtteRutingTask(
 
     companion object {
         const val TASK_STEP_TYPE = "journalhendelseKontantstøtteRuting"
-        val logger = LoggerFactory.getLogger(this::class.java)
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettJournalføringOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettJournalføringOppgaveTask.kt
@@ -2,9 +2,11 @@ package no.nav.familie.baks.mottak.task
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
+import no.nav.familie.baks.mottak.integrasjoner.Journalpost
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalstatus
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveClient
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -25,9 +27,13 @@ class OpprettJournalføringOppgaveTask(
 ) : AsyncTaskStep {
 
     val log: Logger = LoggerFactory.getLogger(OpprettJournalføringOppgaveTask::class.java)
-    val oppgaverOpprettetCounter: Counter = Metrics.counter("barnetrygd.ruting.oppgave.opprettet")
-    val oppgaverOppdatertCounter: Counter = Metrics.counter("barnetrygd.ruting.oppgave.oppdatert")
-    val skippetOppgaveCounter: Counter = Metrics.counter("barnetrygd.ruting.oppgave.skippet")
+    val barnetrygdOppgaverOpprettetCounter: Counter = Metrics.counter("barnetrygd.ruting.oppgave.opprettet")
+    val barnetrygdOppgaverOppdatertCounter: Counter = Metrics.counter("barnetrygd.ruting.oppgave.oppdatert")
+    val barnetrygdOppgaverSkippetCounter: Counter = Metrics.counter("barnetrygd.ruting.oppgave.skippet")
+
+    val kontantstøtteOppgaverOpprettetCounter: Counter = Metrics.counter("kontantstotte.ruting.oppgave.opprettet")
+    val kontantstøtteOppgaverOppdatertCounter: Counter = Metrics.counter("kontantstotte.ruting.oppgave.oppdatert")
+    val kontantstøtteOppgaverSkippetCounter: Counter = Metrics.counter("kontantstotte.ruting.oppgave.skippet")
 
     override fun doTask(task: Task) {
         val sakssystemMarkering = task.payload
@@ -35,16 +41,18 @@ class OpprettJournalføringOppgaveTask(
         val journalpost = journalpostClient.hentJournalpost(task.metadata["journalpostId"] as String)
         when (journalpost.journalstatus) {
             Journalstatus.MOTTATT -> {
-                val journalføringsOppgaver = oppgaveClient.finnOppgaver(journalpost.journalpostId, Oppgavetype.Journalføring)
+                val journalføringsOppgaver =
+                    oppgaveClient.finnOppgaver(journalpost.journalpostId, Oppgavetype.Journalføring)
                 val oppgaveTypeForEksisterendeOppgave: Oppgavetype? =
                     if (journalføringsOppgaver.isNotEmpty()) {
                         Oppgavetype.Journalføring
-                    } else if (oppgaveClient.finnOppgaver(journalpost.journalpostId, Oppgavetype.Fordeling).isNotEmpty()) {
+                    } else if (oppgaveClient.finnOppgaver(journalpost.journalpostId, Oppgavetype.Fordeling)
+                        .isNotEmpty()
+                    ) {
                         Oppgavetype.Fordeling
                     } else {
                         null
                     }
-
                 if (oppgaveTypeForEksisterendeOppgave == null) {
                     val nyOppgave = oppgaveClient.opprettJournalføringsoppgave(
                         journalpost = journalpost,
@@ -52,13 +60,13 @@ class OpprettJournalføringOppgaveTask(
                     )
                     task.metadata["oppgaveId"] = "${nyOppgave.oppgaveId}"
                     log.info("Oppretter ny journalførings-oppgave med id ${nyOppgave.oppgaveId} for journalpost ${journalpost.journalpostId}")
-                    oppgaverOpprettetCounter.increment()
+                    incrementOppgaverOpprettet(journalpost)
                 } else {
                     log.info("Skipper oppretting av journalførings-oppgave. Fant åpen oppgave av type $oppgaveTypeForEksisterendeOppgave for ${journalpost.journalpostId}")
                     if (sakssystemMarkering.isNotEmpty()) {
                         journalføringsOppgaver.forEach {
                             it.oppdaterOppgavebeskrivelse(sakssystemMarkering)
-                            oppgaverOppdatertCounter.increment()
+                            incrementOppgaverOppdatert(journalpost)
                         }
                     }
                 }
@@ -66,7 +74,7 @@ class OpprettJournalføringOppgaveTask(
 
             Journalstatus.JOURNALFOERT -> {
                 log.info("Skipper journalpost ${journalpost.journalpostId} som alt er i status JOURNALFOERT")
-                skippetOppgaveCounter.increment()
+                incrementOppgaverSkippet(journalpost)
             }
 
             else -> {
@@ -76,6 +84,30 @@ class OpprettJournalføringOppgaveTask(
                 log.info("OpprettJournalføringOppgaveTask feilet.", error)
                 throw error
             }
+        }
+    }
+
+    private fun incrementOppgaverOpprettet(journalpost: Journalpost) {
+        if (journalpost.tema == Tema.BAR.name) {
+            barnetrygdOppgaverOpprettetCounter.increment()
+        } else {
+            kontantstøtteOppgaverOpprettetCounter.increment()
+        }
+    }
+
+    private fun incrementOppgaverOppdatert(journalpost: Journalpost) {
+        if (journalpost.tema == Tema.BAR.name) {
+            barnetrygdOppgaverOppdatertCounter.increment()
+        } else {
+            kontantstøtteOppgaverOppdatertCounter.increment()
+        }
+    }
+
+    private fun incrementOppgaverSkippet(journalpost: Journalpost) {
+        if (journalpost.tema == Tema.BAR.name) {
+            barnetrygdOppgaverSkippetCounter.increment()
+        } else {
+            kontantstøtteOppgaverSkippetCounter.increment()
         }
     }
 

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -83,6 +83,7 @@ FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner-q1.dev-fss-pub.nais
 FAMILIE_INTEGRASJONER_SCOPE: api://dev-fss.teamfamilie.familie-integrasjoner-q1/.default
 
 FAMILIE_BA_INFOTRYGD_API_URL: https://familie-ba-infotrygd.dev-fss-pub.nais.io
+FAMILIE_KS_INFOTRYGD_API_URL: https://familie-ks-infotrygd.dev-fss-pub.nais.io
 
 FAMILIE_BA_SAK_API_URL: http://familie-ba-sak/api
 BA_SAK_SCOPE: api://dev-gcp.teamfamilie.familie-ba-sak/.default

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -48,6 +48,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      familie-ks-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_KS_INFOTRYGD_API_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: api://dev-fss.teamfamilie.familie-ks-infotrygd/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       dokument-clientauth:
         resource-url: ${FAMILIE_DOKUMENT_API_URL}
         well-known-url: ${TOKEN_X_WELL_KNOWN_URL}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -48,6 +48,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      familie-ks-infotrygd-clientcredentials:
+        resource-url: ${FAMILIE_KS_INFOTRYGD_API_URL}
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: api://prod-fss.teamfamilie.familie-ks-infotrygd/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       dokument-clientauth:
         resource-url: ${FAMILIE_DOKUMENT_API_URL}
         well-known-url: ${TOKEN_X_WELL_KNOWN_URL}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -80,6 +80,7 @@ FAMILIE_BA_DOKGEN_API_URL: https://familie-ba-dokgen.intern.nav.no
 FAMILIE_BA_SAK_API_URL: https://familie-ba-sak.intern.nav.no/api
 BA_SAK_SCOPE: api://prod-gcp.teamfamilie.familie-ba-sak/.default
 FAMILIE_BA_INFOTRYGD_API_URL: https://familie-ba-infotrygd.prod-fss-pub.nais.io
+FAMILIE_KS_INFOTRYGD_API_URL: https://familie-ks-infotrygd.prod-fss-pub.nais.io
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.prod-fss-pub.nais.io/api
 FAMILIE_INTEGRASJONER_SCOPE: api://prod-fss.teamfamilie.familie-integrasjoner/.default
 PDL_URL: https://pdl-api.prod-fss-pub.nais.io

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,6 +77,7 @@ FAMILIE_BA_DOKGEN_API_URL: http://familie-ba-dokgen.default
 FAMILIE_INTEGRASJONER_API_URL: https://familie-integrasjoner.prod-fss-pub.nais.io/api
 FAMILIE_DOKUMENT_API_URL: http://familie-dokument
 FAMILIE_BA_INFOTRYGD_API_URL: http://familie-ba-infotrygd
+FAMILIE_KS_INFOTRYGD_API_URL: http://familie-ks-infotrygd
 STS_URL: http://security-token-service.default.svc.nais.local/rest/v1/sts/token
 PDL_URL: http://pdl-api.pdl
 ACCEPTEDAUDIENCE: dummy

--- a/src/test/kotlin/no/nav/familie/baks/mottak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/config/ClientMocks.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.baks.mottak.integrasjoner.Bruker
 import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
 import no.nav.familie.baks.mottak.integrasjoner.DokarkivClient
+import no.nav.familie.baks.mottak.integrasjoner.DokumentInfo
 import no.nav.familie.baks.mottak.integrasjoner.Journalpost
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalposttype
@@ -96,6 +97,26 @@ class ClientMocks {
             bruker = Bruker("12345678901", BrukerIdType.FNR),
             tema = "BAR",
             kanal = "SKAN_NETS"
+        )
+
+        every { mockJournalpostClient.hentJournalpost("456") } returns Journalpost(
+            journalpostId = "1456",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            bruker = Bruker("123456789012", BrukerIdType.AKTOERID),
+            tema = "KON",
+            kanal = "NO_NAV",
+            behandlingstema = null,
+            dokumenter = listOf(
+                DokumentInfo(
+                    tittel = "Søknad om kontantstøtte til småbarnsforeldre",
+                    brevkode = "34-00.08",
+                    dokumentstatus = null,
+                    dokumentvarianter = emptyList()
+                )
+            ),
+            journalforendeEnhet = null,
+            sak = null
         )
 
         return mockJournalpostClient

--- a/src/test/kotlin/no/nav/familie/baks/mottak/config/ClientMocks.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/config/ClientMocks.kt
@@ -33,7 +33,7 @@ class ClientMocks {
         val mockOppgaveClient = mockk<OppgaveClient>(relaxed = true)
 
         every {
-            mockOppgaveClient.opprettJournalføringsoppgave(any())
+            mockOppgaveClient.opprettJournalføringsoppgave(any(), any())
         } returns OppgaveResponse(1L)
 
         return mockOppgaveClient

--- a/src/test/kotlin/no/nav/familie/baks/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -368,7 +368,8 @@ class JournalføringHendelseServiceTest {
 
     @Test
     fun `Ikke gyldige hendelsetyper skal ignoreres`() {
-        val ugyldigHendelsetypeRecord = opprettRecord(journalpostId = JOURNALPOST_PAPIRSØKNAD, hendelseType = "UgyldigType", temaNytt = "BAR")
+        val ugyldigHendelsetypeRecord =
+            opprettRecord(journalpostId = JOURNALPOST_PAPIRSØKNAD, hendelseType = "UgyldigType", temaNytt = "BAR")
         val consumerRecord = ConsumerRecord(
             "topic",
             1,

--- a/src/test/kotlin/no/nav/familie/baks/mottak/hendelser/JournalføringHendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/hendelser/JournalføringHendelseServiceTest.kt
@@ -154,7 +154,7 @@ class JournalføringHendelseServiceTest {
             journalposttype = Journalposttype.U,
             journalstatus = Journalstatus.FERDIGSTILT,
             bruker = Bruker("123456789012", BrukerIdType.AKTOERID),
-            tema = "FOR",
+            tema = "BAR",
             kanal = "NAV_NO",
             behandlingstema = null,
             dokumenter = null,

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClientTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.Ressurs.Companion.success
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -270,7 +271,7 @@ class OppgaveClientTest {
             "1234567",
             Journalposttype.I,
             Journalstatus.MOTTATT,
-            "tema",
+            Tema.BAR.name,
             "behandlingstemaFraJournalpost",
             null,
             Bruker("1234567891011", BrukerIdType.AKTOERID),

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -32,11 +32,15 @@ class OppgaveMapperTest(
 
     private val mockHentEnhetClient: HentEnhetClient = mockk(relaxed = true)
 
+    private val barnetrygdOppgaveMapper: IOppgaveMapper = BarnetrygdOppgaveMapper(mockHentEnhetClient, mockPdlClient)
+
+    private val kontantstøtteOppgaveMapper: IOppgaveMapper =
+        KontantstøtteOppgaveMapper(mockHentEnhetClient, mockPdlClient)
+
     @Test
     fun `skal kaste exception dersom dokumentlisten er tom`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         Assertions.assertThrows(IllegalStateException::class.java) {
-            oppgaveMapper.mapTilOpprettOppgave(
+            barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
                 Oppgavetype.Journalføring,
                 journalpostClient.hentJournalpost("123")
                     .copy(dokumenter = listOf())
@@ -46,9 +50,8 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal kaste exception dersom brukerid ikke er satt når oppgavetype er BehandleSak`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         Assertions.assertThrows(IllegalStateException::class.java) {
-            oppgaveMapper.mapTilOpprettOppgave(
+            barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
                 Oppgavetype.BehandleSak,
                 journalpostClient.hentJournalpost("123")
                     .copy(
@@ -70,8 +73,7 @@ class OppgaveMapperTest(
     fun `skal sette brukerid til null dersom bruker ikke finnes i PDL når oppgavetype er Journalføring`() {
         every { mockPdlClient.hentIdenter(any()) } throws IntegrasjonException("Fant ikke person")
 
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("321")
                 .copy(
@@ -90,9 +92,8 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal ikke kaste exception selvom brukerid mangler når oppgavetype er Journalføring`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         Assertions.assertDoesNotThrow {
-            oppgaveMapper.mapTilOpprettOppgave(
+            barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
                 Oppgavetype.Journalføring,
                 journalpostClient.hentJournalpost("123")
                     .copy(
@@ -112,8 +113,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette behandlingstema Ordinær`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -132,8 +132,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette behandlingstema Ordinær uavhengig av journalpost`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -153,8 +152,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette behandlingstema EØS`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -178,8 +176,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette behandlingstype Utland`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -206,8 +203,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette beskrivelse til kun tittel på journalpost når beskrivelse i input er null, brevkode på journalpost er satt og dokumentet har tittel`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -228,9 +224,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette beskrivelse til tom når beskrivelse i input er null, brevkode på journalpost er ikke satt og dokumentet har tittel`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-
-        val oppgaveUtenBeskrivelse1 = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgaveUtenBeskrivelse1 = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -250,8 +244,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette beskrivelse til tom når beskrivelse i input er null, brevkode på journalpost er ikke satt og dokumentet ikke har tittel`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgaveUtenBeskrivelse2 = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgaveUtenBeskrivelse2 = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -271,8 +264,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette beskrivelse til tittel og beskrivelse når beskrivelse i input er satt, brevkode på journalpost er satt og dokumentet har tittel`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgaveUtenBeskrivelse2 = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgaveUtenBeskrivelse2 = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -293,8 +285,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette beskrivelse til kun beskrivelse fra input når dokumentet mangler tittel`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgaveUtenBeskrivelse2 = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgaveUtenBeskrivelse2 = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -315,8 +306,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette enhet 4806 hvis enhet på journalpost er 2101`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -337,8 +327,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette enhet null hvis enhet på journalpost er null`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -360,8 +349,7 @@ class OppgaveMapperTest(
     @Test
     fun `skal sette enhet fra journalpost hvis enhet kan behandle oppgaver`() {
         every { mockHentEnhetClient.hentEnhet("4") } returns Enhet("4", "enhetnavn", true, "Aktiv")
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -383,8 +371,7 @@ class OppgaveMapperTest(
     @Test
     fun `skal sette enhet null hvis enhet ikke kan behandle oppgaver`() {
         every { mockHentEnhetClient.hentEnhet("5") } returns Enhet("4", "enhetnavn", false, "Aktiv")
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -406,8 +393,7 @@ class OppgaveMapperTest(
     @Test
     fun `skal sette enhet null hvis enhet er nedlagt`() {
         every { mockHentEnhetClient.hentEnhet("5") } returns Enhet("4", "enhetnavn", true, "Nedlagt")
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -428,8 +414,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette bruker null hvis Orgnr  er 000000000`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -451,8 +436,7 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal sette orgnr hvis Orgnr  er satt`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val oppgave = oppgaveMapper.mapTilOpprettOppgave(
+        val oppgave = barnetrygdOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("123")
                 .copy(
@@ -474,9 +458,8 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal kaste feil dersom tema ikke er satt`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         val exception = assertThrows<RuntimeException> {
-            oppgaveMapper.mapTilOpprettOppgave(
+            kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
                 Oppgavetype.Journalføring,
                 journalpostClient.hentJournalpost("456")
                     .copy(
@@ -492,9 +475,8 @@ class OppgaveMapperTest(
 
     @Test
     fun `skal kaste feil dersom tema ikke finnes i Tema enum`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         val exception = assertThrows<RuntimeException> {
-            oppgaveMapper.mapTilOpprettOppgave(
+            kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
                 Oppgavetype.Journalføring,
                 journalpostClient.hentJournalpost("456")
                     .copy(
@@ -509,20 +491,18 @@ class OppgaveMapperTest(
     }
 
     @Test
-    fun `skal sette riktig tema og behandlingstema på OpprettOppgaveRequest for kontantstøtte`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val opprettOppgaveRequest = oppgaveMapper.mapTilOpprettOppgave(
+    fun `skal sette behandlingstype NASJONAL dersom tema er KON og søknad ikke er EØS søknad`() {
+        val opprettOppgaveRequest = kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("456")
         )
         assertEquals(Tema.KON, opprettOppgaveRequest.tema)
-        assertEquals(Behandlingstema.Kontantstøtte.value, opprettOppgaveRequest.behandlingstema)
+        assertEquals(Behandlingstype.NASJONAL.value, opprettOppgaveRequest.behandlingstype)
     }
 
     @Test
     fun `skal sette behandlingstype EØS dersom tema er KON og bruker id er Dnummer`() {
-        val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
-        val opprettOppgaveRequest = oppgaveMapper.mapTilOpprettOppgave(
+        val opprettOppgaveRequest = kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,
             journalpostClient.hentJournalpost("456").copy(
                 bruker = Bruker(

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -491,7 +491,7 @@ class OppgaveMapperTest(
     }
 
     @Test
-    fun `skal kaste feil dersom tema ikke er finnes i Tema enum`() {
+    fun `skal kaste feil dersom tema ikke finnes i Tema enum`() {
         val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         val exception = assertThrows<RuntimeException> {
             oppgaveMapper.mapTilOpprettOppgave(

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -485,7 +485,7 @@ class OppgaveMapperTest(
             )
         }
         assertEquals(
-            "Feil ved mapping til OpprettOppgaveRequest. Tema for journalpost er tomt eller ugyldig: ${null}",
+            "Tema for journalpost er tomt eller ugyldig: ${null}",
             exception.message
         )
     }
@@ -503,7 +503,7 @@ class OppgaveMapperTest(
             )
         }
         assertEquals(
-            "Feil ved mapping til OpprettOppgaveRequest. Tema for journalpost er tomt eller ugyldig: UGYLDIG",
+            "Tema for journalpost er tomt eller ugyldig: UGYLDIG",
             exception.message
         )
     }
@@ -520,7 +520,7 @@ class OppgaveMapperTest(
     }
 
     @Test
-    fun `skal sette behandlingstema KontantstøtteEØS dersom tema er KON og bruker id er Dnummer`() {
+    fun `skal sette behandlingstype EØS dersom tema er KON og bruker id er Dnummer`() {
         val oppgaveMapper = OppgaveMapper(mockHentEnhetClient, mockPdlClient)
         val opprettOppgaveRequest = oppgaveMapper.mapTilOpprettOppgave(
             Oppgavetype.Journalføring,
@@ -532,6 +532,7 @@ class OppgaveMapperTest(
             )
         )
         assertEquals(Tema.KON, opprettOppgaveRequest.tema)
-        assertEquals(Behandlingstema.KontantstøtteEØS.value, opprettOppgaveRequest.behandlingstema)
+        assertEquals(null, opprettOppgaveRequest.behandlingstema)
+        assertEquals(Behandlingstype.EØS.value, opprettOppgaveRequest.behandlingstype)
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -457,40 +457,6 @@ class OppgaveMapperTest(
     }
 
     @Test
-    fun `skal kaste feil dersom tema ikke er satt`() {
-        val exception = assertThrows<RuntimeException> {
-            kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
-                Oppgavetype.Journalføring,
-                journalpostClient.hentJournalpost("456")
-                    .copy(
-                        tema = null
-                    )
-            )
-        }
-        assertEquals(
-            "Tema for journalpost er tomt eller ugyldig: ${null}",
-            exception.message
-        )
-    }
-
-    @Test
-    fun `skal kaste feil dersom tema ikke finnes i Tema enum`() {
-        val exception = assertThrows<RuntimeException> {
-            kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
-                Oppgavetype.Journalføring,
-                journalpostClient.hentJournalpost("456")
-                    .copy(
-                        tema = "UGYLDIG"
-                    )
-            )
-        }
-        assertEquals(
-            "Tema for journalpost er tomt eller ugyldig: UGYLDIG",
-            exception.message
-        )
-    }
-
-    @Test
     fun `skal sette behandlingstype NASJONAL dersom tema er KON og søknad ikke er EØS søknad`() {
         val opprettOppgaveRequest = kontantstøtteOppgaveMapper.tilOpprettOppgaveRequest(
             Oppgavetype.Journalføring,

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTaskTest.kt
@@ -6,6 +6,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.familie.baks.mottak.config.FeatureToggleConfig
+import no.nav.familie.baks.mottak.config.FeatureToggleService
 import no.nav.familie.baks.mottak.domene.personopplysning.Person
 import no.nav.familie.baks.mottak.integrasjoner.BarnDto
 import no.nav.familie.baks.mottak.integrasjoner.Foedselsnummer
@@ -37,6 +39,9 @@ class JournalhendelseKontantstøtteRutingTaskTest {
     @MockK
     private lateinit var taskService: TaskService
 
+    @MockK
+    private lateinit var featureToggleService: FeatureToggleService
+
     @InjectMockKs
     private lateinit var journalhendelseKontantstøtteRutingTask: JournalhendelseKontantstøtteRutingTask
 
@@ -48,6 +53,7 @@ class JournalhendelseKontantstøtteRutingTaskTest {
     fun `doTask - skal opprette OpprettJournalføringOppgaveTask med informasjon om at det finnes løpende sak i Infotrygd når et eller flere av barna har løpende sak i Infotrygd`() {
         val taskSlot = slot<Task>()
         setupPDLMocks()
+        setupFeatureToggleMocks()
         every { infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(any()) } returns true
         every { infotrygdKontantstøtteClient.hentPerioderMedKontantstøtteIInfotrygd(any()) } returns InnsynResponse(
             data = listOf(
@@ -80,6 +86,7 @@ class JournalhendelseKontantstøtteRutingTaskTest {
     fun `doTask - skal opprette OpprettJournalføringOppgaveTask med tom sakssystem-markering når et eller flere av barna har sak i Infotrygd men ingen løpende`() {
         val taskSlot = slot<Task>()
         setupPDLMocks()
+        setupFeatureToggleMocks()
         every { infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(any()) } returns true
         every { infotrygdKontantstøtteClient.hentPerioderMedKontantstøtteIInfotrygd(any()) } returns InnsynResponse(
             data = listOf(
@@ -112,6 +119,7 @@ class JournalhendelseKontantstøtteRutingTaskTest {
     fun `doTask - skal opprette OpprettJournalføringOppgaveTask med tom sakssystem-markering når ingen av barna har sak i Infotrygd`() {
         val taskSlot = slot<Task>()
         setupPDLMocks()
+        setupFeatureToggleMocks()
         every { infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(any()) } returns false
 
         every { taskService.save(capture(taskSlot)) } returns mockk()
@@ -149,5 +157,14 @@ class JournalhendelseKontantstøtteRutingTaskTest {
                 historisk = false
             )
         )
+    }
+
+    private fun setupFeatureToggleMocks() {
+        every {
+            featureToggleService.isEnabled(
+                FeatureToggleConfig.OPPRETTE_JOURNALFØRINGSOPPGAVE_KONTANTSTØTTE,
+                false
+            )
+        } returns true
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTaskTest.kt
@@ -1,0 +1,153 @@
+package no.nav.familie.baks.mottak.task
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.baks.mottak.domene.personopplysning.Person
+import no.nav.familie.baks.mottak.integrasjoner.BarnDto
+import no.nav.familie.baks.mottak.integrasjoner.Foedselsnummer
+import no.nav.familie.baks.mottak.integrasjoner.IdentInformasjon
+import no.nav.familie.baks.mottak.integrasjoner.InfotrygdKontantstøtteClient
+import no.nav.familie.baks.mottak.integrasjoner.InnsynResponse
+import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.baks.mottak.integrasjoner.StonadDto
+import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
+import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
+import no.nav.familie.kontrakter.felles.personopplysning.ForelderBarnRelasjon
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.YearMonth
+import java.util.*
+import kotlin.test.assertEquals
+
+@ExtendWith(MockKExtension::class)
+class JournalhendelseKontantstøtteRutingTaskTest {
+
+    @MockK
+    private lateinit var pdlClient: PdlClient
+
+    @MockK
+    private lateinit var infotrygdKontantstøtteClient: InfotrygdKontantstøtteClient
+
+    @MockK
+    private lateinit var taskService: TaskService
+
+    @InjectMockKs
+    private lateinit var journalhendelseKontantstøtteRutingTask: JournalhendelseKontantstøtteRutingTask
+
+    val søkerFnr = "12345678910"
+    val barn1Fnr = "11223344556"
+    val barn2Fnr = "11223344557"
+
+    @Test
+    fun `doTask - skal opprette OpprettJournalføringOppgaveTask med informasjon om at det finnes løpende sak i Infotrygd når et eller flere av barna har løpende sak i Infotrygd`() {
+        val taskSlot = slot<Task>()
+        setupPDLMocks()
+        every { infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(any()) } returns true
+        every { infotrygdKontantstøtteClient.hentPerioderMedKontantstøtteIInfotrygd(any()) } returns InnsynResponse(
+            data = listOf(
+                StonadDto(
+                    fnr = Foedselsnummer(søkerFnr),
+                    YearMonth.now().minusMonths(5),
+                    YearMonth.now().plusMonths(1),
+                    belop = 1000,
+                    listOf(
+                        BarnDto(Foedselsnummer(barn1Fnr)),
+                        BarnDto(Foedselsnummer(barn2Fnr))
+                    )
+                )
+            )
+        )
+        every { taskService.save(capture(taskSlot)) } returns mockk()
+
+        journalhendelseKontantstøtteRutingTask.doTask(
+            Task(
+                type = JournalhendelseKontantstøtteRutingTask.TASK_STEP_TYPE,
+                payload = "NAV_NO",
+                properties = Properties().apply { this["personIdent"] = søkerFnr }
+            )
+        )
+
+        assertEquals("Et eller flere av barna har løpende sak i Infotrygd", taskSlot.captured.payload)
+    }
+
+    @Test
+    fun `doTask - skal opprette OpprettJournalføringOppgaveTask med tom sakssystem-markering når et eller flere av barna har sak i Infotrygd men ingen løpende`() {
+        val taskSlot = slot<Task>()
+        setupPDLMocks()
+        every { infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(any()) } returns true
+        every { infotrygdKontantstøtteClient.hentPerioderMedKontantstøtteIInfotrygd(any()) } returns InnsynResponse(
+            data = listOf(
+                StonadDto(
+                    fnr = Foedselsnummer(søkerFnr),
+                    YearMonth.now().minusMonths(8),
+                    YearMonth.now().minusMonths(1),
+                    belop = 1000,
+                    listOf(
+                        BarnDto(Foedselsnummer(barn1Fnr)),
+                        BarnDto(Foedselsnummer(barn2Fnr))
+                    )
+                )
+            )
+        )
+        every { taskService.save(capture(taskSlot)) } returns mockk()
+
+        journalhendelseKontantstøtteRutingTask.doTask(
+            Task(
+                type = JournalhendelseKontantstøtteRutingTask.TASK_STEP_TYPE,
+                payload = "NAV_NO",
+                properties = Properties().apply { this["personIdent"] = søkerFnr }
+            )
+        )
+
+        assertEquals("", taskSlot.captured.payload)
+    }
+
+    @Test
+    fun `doTask - skal opprette OpprettJournalføringOppgaveTask med tom sakssystem-markering når ingen av barna har sak i Infotrygd`() {
+        val taskSlot = slot<Task>()
+        setupPDLMocks()
+        every { infotrygdKontantstøtteClient.harKontantstøtteIInfotrygd(any()) } returns false
+
+        every { taskService.save(capture(taskSlot)) } returns mockk()
+
+        journalhendelseKontantstøtteRutingTask.doTask(
+            Task(
+                type = JournalhendelseKontantstøtteRutingTask.TASK_STEP_TYPE,
+                payload = "NAV_NO",
+                properties = Properties().apply { this["personIdent"] = søkerFnr }
+            )
+        )
+
+        assertEquals("", taskSlot.captured.payload)
+    }
+
+    private fun setupPDLMocks() {
+        every { pdlClient.hentPersonMedRelasjoner(any()) } returns Person(
+            navn = "Ola Norman",
+            forelderBarnRelasjoner = setOf(
+                ForelderBarnRelasjon(barn1Fnr, FORELDERBARNRELASJONROLLE.BARN),
+                ForelderBarnRelasjon(barn2Fnr, FORELDERBARNRELASJONROLLE.BARN)
+            )
+        )
+        every { pdlClient.hentIdenter(barn1Fnr) } returns listOf(
+            IdentInformasjon(
+                ident = barn1Fnr,
+                gruppe = IdentGruppe.FOLKEREGISTERIDENT.name,
+                historisk = false
+            )
+        )
+        every { pdlClient.hentIdenter(barn2Fnr) } returns listOf(
+            IdentInformasjon(
+                ident = barn2Fnr,
+                gruppe = IdentGruppe.FOLKEREGISTERIDENT.name,
+                historisk = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
Håndterer nå også journalhendelser for kontantstøttesøknader på samme måte som for barnetrygdsøknader.

Når journalhendelsen for kontantstøttesøknaden plukkes opp, opprettes den nye tasken `JournalhendelseKontantstøtteRutingTask` som sjekker om noen av de involverte barna i søknaden har løpende kontantstøtte i Infotrygd. Deretter opprettes tasken `OpprettJournalførringOppgaveTask` med en eventuell beskrivelse av at det finnes løpende kontantstøtte i Infotrygd.

`OpprettJournalførringOppgaveTask` fungerer likt for både barnetrygd og kontantstøtte. Eneste endringen her er mappingen til `OpprettOppgaveRequest` som nå gjøres av henholdsvis `BarnetrygdOppgaveMapper` og `KontantstøtteOppgaveMapper`, hvor felles funksjonalitet ligger i den abtrakte klassen `AbstractOppgaveMapper`.

Det er lagt til en feature-toggle rundt tasken `JournalhendelseKontantstøtteRutingTask`, som kun er enabled i `dev-gcp`. I prod vil vi derfor foreløpig ikke opprette journalføringsoppgaver for kontantstøttesøknader.

![image](https://user-images.githubusercontent.com/70642183/210317930-29cb3438-3e8c-4ad9-bddc-c76ebafcc698.png)