### PR TITLE
Skrur av feilhåndtering for topic i preprod, siden topicen kun finnes med data fra q1 og ikke syntetisk data

### DIFF
--- a/src/test/kotlin/no/nav/familie/baks/mottak/hendelser/EnsligForsørgerInfotrygdHendelseConsumerTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/hendelser/EnsligForsørgerInfotrygdHendelseConsumerTest.kt
@@ -54,7 +54,7 @@ class EnsligForsørgerInfotrygdHendelseConsumerTest {
         mockSakClient = mockk(relaxed = true)
         mockPdlClient = mockk(relaxed = true)
         service = EnsligForsørgerHendelseService(mockSakClient, mockPdlClient, mockHendelsesloggRepository)
-        consumer = EnsligForsørgerInfotrygdHendelseConsumer(service)
+        consumer = EnsligForsørgerInfotrygdHendelseConsumer(service, mockk(relaxed = true))
         clearAllMocks()
 
         every { mockPdlClient.hentPersonident("2424242424241") } returns "12345678910"


### PR DESCRIPTION
Lesing av aapen-ef-overgangstonad-v1 i preprod skaper en del støy, siden identene i denne topic er fra Infotrygd og de går mot q1. Siden vi har sluttet å gå mot q1, så får man feil i loggene om at identen ikke finnes og man klarer ikke å lese topicen. Denne PR logger og fortsetter i stedet hvis miljø er preprod, i stedet for å kaste feilen opp til kafka sin error handler.
