### PR TITLE
Setter upp max-lifetime for hikari for å redusere connection closed logging

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
     hikari:
       maximum-pool-size: 10
       connection-test-query: "select 1"
-      max-lifetime: 30000
+      max-lifetime: 900000
       minimum-idle: 1
   jpa:
     hibernate:


### PR DESCRIPTION
Skrur opp max-lifetime i hikari-configen for å redusere antall connection closed logging. Til en verdi som er mye nærmere default-verdien. En sammenligning mellom før og nå.
![Screenshot 2023-01-17 at 12 26 23](https://user-images.githubusercontent.com/1121978/212887973-d0df6c02-7da2-4dce-bf4c-bac1661e480f.png)

Branch har kjørt 1 døgn i preprod uten restarts. Samme endring kjører i prod for migrering uten at jeg ser noen ulemper med den
<img width="508" alt="Screenshot 2023-01-17 at 12 26 37" src="https://user-images.githubusercontent.com/1121978/212887763-45e41b1d-b293-4912-b762-607731c7507f.png">


