### PR TITLE
Fix/oppdatere ingress

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -36,6 +36,8 @@ spec:
     requests:
       memory: 1024Mi
       cpu: 200m
+  ingresses:
+    - https://familie-baks-mottak.dev.intern.nav.no
   secureLogs:
     enabled: true
   tokenx:

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -58,6 +58,8 @@ spec:
           cluster: dev-gcp
         - application: familie-dokument
           cluster: dev-gcp
+        - application: familie-baks-dokgen
+          cluster: dev-gcp
       external:
         - host: kafka-schema-registry.nais-q.adeo.no
         - host: pdl-api.dev-fss-pub.nais.io

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -36,8 +36,6 @@ spec:
     requests:
       memory: 1024Mi
       cpu: 200m
-  ingresses:
-    - https://familie-baks-mottak.dev.intern.nav.no
   secureLogs:
     enabled: true
   tokenx:

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -36,6 +36,8 @@ spec:
     requests:
       memory: 2Gi
       cpu: 200m
+  ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
+    - https://familie-baks-mottak.intern.nav.no
   secureLogs:
     enabled: true
   tokenx:

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -36,8 +36,6 @@ spec:
     requests:
       memory: 2Gi
       cpu: 200m
-  ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
-    - https://familie-baks-mottak.intern.nav.no
   secureLogs:
     enabled: true
   tokenx:

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -63,8 +63,6 @@ spec:
         - host: pdl-api.prod-fss-pub.nais.io
         - host: norg2.prod-fss-pub.nais.io
         - host: familie-integrasjoner.prod-fss-pub.nais.io
-  ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
-    - https://familie-baks-mottak.intern.nav.no
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -93,4 +93,4 @@ BA_SAK_SCOPE: api://dev-gcp.teamfamilie.familie-ba-sak/.default
 
 NORG2_API_URL: https://norg2.dev-fss-pub.nais.io/norg2
 FAMILIE_DOKUMENT_API_URL: http://familie-dokument/familie/dokument
-FAMILIE_BAKS_DOKGEN_API_URL: https://familie-baks-dokgen.dev.intern.nav.no
+FAMILIE_BAKS_DOKGEN_API_URL: https://familie-baks-dokgen/

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -4,7 +4,7 @@ no.nav.security.jwt:
     accepted_audience: ${AZURE_APP_CLIENT_ID}
     cookie_name: azure_token
   issuer.selvbetjening:
-    discoveryurl: https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
+    discoveryurl: https://oidc-ver2.difi.no/idporten-oidc-provider/.well-known/openid-configuration
     accepted_audience: ${ACCEPTEDAUDIENCE}
     cookie_name: selvbetjening-idtoken
   issuer.tokenx:

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -89,4 +89,4 @@ BA_SAK_SCOPE: api://dev-gcp.teamfamilie.familie-ba-sak/.default
 
 NORG2_API_URL: https://norg2.dev-fss-pub.nais.io/norg2
 FAMILIE_DOKUMENT_API_URL: http://familie-dokument/familie/dokument
-FAMILIE_BAKS_DOKGEN_API_URL: https://familie-baks-dokgen/
+FAMILIE_BAKS_DOKGEN_API_URL: http://familie-baks-dokgen


### PR DESCRIPTION
Fjerner `ingresses` fra nais-yaml da ingen applikasjoner kommuniserer med appen via denne. Alle bruker allerede service discovery. Alternativet hadde vært å endre til korrekte ingresser, men det er altså foreløpig ikke nødvendig.