### PR TITLE
Flyttet logikk for søknads-metrikker ut av søknads-controllere

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/AbstractSøknadMetricsService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/AbstractSøknadMetricsService.kt
@@ -1,0 +1,3 @@
+package no.nav.familie.baks.mottak.søknad
+
+abstract class AbstractSøknadMetricsService

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/AbstractSøknadMetricsService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/AbstractSøknadMetricsService.kt
@@ -1,3 +1,0 @@
-package no.nav.familie.baks.mottak.søknad
-
-abstract class AbstractSøknadMetricsService

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/JournalføringService.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.integrasjoner.DokarkivClient
-import no.nav.familie.baks.mottak.søknad.barnetrygd.SøknadService
+import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Service
 @Service
 class JournalføringService(
     private val dokarkivClient: DokarkivClient,
-    private val søknadService: SøknadService,
+    private val barnetrygdSøknadService: BarnetrygdSøknadService,
     private val kontantstøtteSøknadService: KontantstøtteSøknadService,
 ) {
 
     fun journalførBarnetrygdSøknad(dbSøknad: DBSøknad, pdf: ByteArray, pdfOriginalSpråk: ByteArray = ByteArray(0)) {
         if (dbSøknad.journalpostId == null) {
-            val vedlegg = søknadService.hentLagredeVedlegg(dbSøknad)
+            val vedlegg = barnetrygdSøknadService.hentLagredeVedlegg(dbSøknad)
 
             val arkiverDokumentRequest = ArkiverDokumentRequestMapper.toDto(
                 dbSøknad = dbSøknad,
@@ -30,10 +30,10 @@ class JournalføringService(
             )
             val journalpostId: String = arkiverSøknad(arkiverDokumentRequest)
             val dbSøknadMedJournalpostId = dbSøknad.copy(journalpostId = journalpostId)
-            søknadService.lagreDBSøknad(dbSøknadMedJournalpostId)
+            barnetrygdSøknadService.lagreDBSøknad(dbSøknadMedJournalpostId)
             log.info("Søknaden er journalført og lagret til database")
 
-            søknadService.slettLagredeVedlegg(dbSøknad)
+            barnetrygdSøknadService.slettLagredeVedlegg(dbSøknad)
             log.info("Vedlegg for søknad slettet fra database etter journalføring")
         } else {
             log.warn("Søknaden har allerede blitt journalført med journalpostId: ${dbSøknad.journalpostId}")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadController.kt
@@ -1,15 +1,10 @@
 package no.nav.familie.baks.mottak.søknad.barnetrygd
 
-import io.micrometer.core.instrument.Metrics
 import no.nav.familie.baks.mottak.søknad.Kvittering
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.FødselsnummerErNullException
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV7
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertSøknad
-import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
-import no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov
-import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
-import no.nav.familie.kontrakter.ba.søknad.v7.Søknadsvedlegg
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
@@ -29,30 +24,8 @@ import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadKontraktV8
 @ProtectedWithClaims(issuer = "tokenx", claimMap = ["acr=Level4"])
 class BarnetrygdSøknadController(
     private val barnetrygdSøknadService: BarnetrygdSøknadService,
+    private val barnetrygdSøknadMetrikkService: BarnetrygdSøknadMetrikkService,
 ) {
-
-    // Metrics for ordinær barnetrygd
-    val søknadMottattOk = Metrics.counter("barnetrygd.soknad.mottatt.ok")
-    val søknadMottattFeil = Metrics.counter("barnetrygd.soknad.mottatt.feil")
-    val søknadHarDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.dokumentasjonsbehov")
-    val antallDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.dokumentasjonsbehov.antall")
-    val søknadHarVedlegg = Metrics.counter("barnetrygd.soknad.harVedlegg")
-    val antallVedlegg = Metrics.counter("barnetrygd.soknad.harVedlegg.antall")
-    val harManglerIDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.harManglerIDokumentasjonsbehov")
-
-    // Metrics for utvidet barnetrygd
-    val søknadUtvidetMottattOk = Metrics.counter("barnetrygd.soknad.utvidet.mottatt.ok")
-    val søknadUtvidetMottattFeil = Metrics.counter("barnetrygd.soknad.utvidet.mottatt.feil")
-    val utvidetSøknadHarDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.dokumentasjonsbehov")
-    val utvidetAntallDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.dokumentasjonsbehov.antall")
-    val utvidetSøknadHarVedlegg = Metrics.counter("barnetrygd.soknad.utvidet.harVedlegg")
-    val utvidetAntallVedlegg = Metrics.counter("barnetrygd.soknad.utvidet.harVedlegg.antall")
-    val utvidetHarManglerIDokumentasjonsbehov =
-        Metrics.counter("barnetrygd.soknad.utvidet.harManglerIDokumentasjonsbehov")
-
-    // Metrics for EØS barnetrygd
-    val ordinærSøknadEøs = Metrics.counter("barnetrygd.ordinaer.soknad.eos")
-    val utvidetSøknadEøs = Metrics.counter("barnetrygd.utvidet.soknad.eos")
 
     @PostMapping(value = ["/soknad/v7"], consumes = [MULTIPART_FORM_DATA_VALUE])
     fun taImotSøknad(@RequestPart("søknad") søknad: SøknadKontraktV7): ResponseEntity<Ressurs<Kvittering>> =
@@ -63,101 +36,14 @@ class BarnetrygdSøknadController(
         mottaVersjonertSøknadOgSendMetrikker(versjonertSøknad = SøknadV8(søknad = søknad))
 
     fun mottaVersjonertSøknadOgSendMetrikker(versjonertSøknad: VersjonertSøknad): ResponseEntity<Ressurs<Kvittering>> {
-        val søknadstype = when (versjonertSøknad) {
-            is SøknadV7 -> versjonertSøknad.søknad.søknadstype
-            is SøknadV8 -> versjonertSøknad.søknad.søknadstype
-        }
-
         return try {
             val dbSøknad = barnetrygdSøknadService.motta(versjonertSøknad = versjonertSøknad)
-            sendMetrics(versjonertSøknad = versjonertSøknad)
+            barnetrygdSøknadMetrikkService.sendMottakMetrikker(versjonertSøknad)
             ResponseEntity.ok(Ressurs.success(Kvittering("Søknad er mottatt", dbSøknad.opprettetTid)))
         } catch (e: FødselsnummerErNullException) {
-            if (søknadstype == Søknadstype.UTVIDET) søknadUtvidetMottattFeil.increment() else søknadMottattFeil.increment()
+            barnetrygdSøknadMetrikkService.sendMottakFeiletMetrikker(versjonertSøknad)
             ResponseEntity.status(500).body(Ressurs.failure("Lagring av søknad feilet"))
         }
-    }
-
-    private fun sendMetrics(versjonertSøknad: VersjonertSøknad) {
-        val (søknadstype, dokumentasjon) = when (versjonertSøknad) {
-            is SøknadV7 -> Pair(versjonertSøknad.søknad.søknadstype, versjonertSøknad.søknad.dokumentasjon)
-            is SøknadV8 -> Pair(versjonertSøknad.søknad.søknadstype, versjonertSøknad.søknad.dokumentasjon)
-        }
-
-        val harEøsSteg = when (versjonertSøknad) {
-            is SøknadV7 -> versjonertSøknad.søknad.antallEøsSteg > 0
-            is SøknadV8 -> versjonertSøknad.søknad.antallEøsSteg > 0
-        }
-
-        val erUtvidet = søknadstype == Søknadstype.UTVIDET
-        sendMetricsSøknad(harEøsSteg, erUtvidet)
-
-        sendMetricsDokumentasjon(erUtvidet, dokumentasjon)
-    }
-
-    private fun sendMetricsSøknad(harEøsSteg: Boolean, erUtvidet: Boolean) {
-        if (erUtvidet) {
-            søknadUtvidetMottattOk.increment()
-            if (harEøsSteg) {
-                utvidetSøknadEøs.increment()
-            }
-        } else {
-            søknadMottattOk.increment()
-            if (harEøsSteg) {
-                ordinærSøknadEøs.increment()
-            }
-        }
-    }
-
-    private fun sendMetricsDokumentasjon(erUtvidet: Boolean, dokumentasjon: List<Søknaddokumentasjon>) {
-        if (dokumentasjon.isNotEmpty()) {
-            // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
-            val dokumentasjonsbehovUtenAnnenDokumentasjon =
-                dokumentasjon.filter { it.dokumentasjonsbehov != Dokumentasjonsbehov.ANNEN_DOKUMENTASJON }
-
-            if (dokumentasjonsbehovUtenAnnenDokumentasjon.isNotEmpty()) {
-                sendMetricsDokumentasjonsbehov(
-                    erUtvidet = erUtvidet,
-                    dokumentasjonsbehov = dokumentasjonsbehovUtenAnnenDokumentasjon,
-                )
-            }
-            // Inkluderer Dokumentasjonsbehov.ANNEN_DOKUMENTASJON for søknadHarVedlegg og antallVedlegg
-            val alleVedlegg: List<Søknadsvedlegg> = dokumentasjon.map { it.opplastedeVedlegg }.flatten()
-            if (alleVedlegg.isNotEmpty()) {
-                sendMetricsVedlegg(erUtvidet = erUtvidet, vedlegg = alleVedlegg)
-            }
-
-            // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
-            val harMangler =
-                dokumentasjonsbehovUtenAnnenDokumentasjon.any { !it.harSendtInn && it.opplastedeVedlegg.isEmpty() }
-            if (harMangler) {
-                sendMetricsManglerVedlegg(erUtvidet = erUtvidet)
-            }
-        }
-    }
-
-    private fun sendMetricsDokumentasjonsbehov(erUtvidet: Boolean, dokumentasjonsbehov: List<Søknaddokumentasjon>) {
-        if (erUtvidet) {
-            utvidetSøknadHarDokumentasjonsbehov.increment()
-            utvidetAntallDokumentasjonsbehov.increment(dokumentasjonsbehov.size.toDouble())
-        } else {
-            søknadHarDokumentasjonsbehov.increment()
-            antallDokumentasjonsbehov.increment(dokumentasjonsbehov.size.toDouble())
-        }
-    }
-
-    private fun sendMetricsVedlegg(erUtvidet: Boolean, vedlegg: List<Søknadsvedlegg>) {
-        if (erUtvidet) {
-            utvidetSøknadHarVedlegg.increment()
-            utvidetAntallVedlegg.increment(vedlegg.size.toDouble())
-        } else {
-            søknadHarVedlegg.increment()
-            antallVedlegg.increment(vedlegg.size.toDouble())
-        }
-    }
-
-    private fun sendMetricsManglerVedlegg(erUtvidet: Boolean) {
-        if (erUtvidet) utvidetHarManglerIDokumentasjonsbehov.increment() else harManglerIDokumentasjonsbehov.increment()
     }
 
     @GetMapping(value = ["/ping"])

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadController.kt
@@ -27,8 +27,8 @@ import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadKontraktV8
 @RestController
 @RequestMapping(path = ["/api"], produces = [APPLICATION_JSON_VALUE])
 @ProtectedWithClaims(issuer = "tokenx", claimMap = ["acr=Level4"])
-class SøknadController(
-    private val søknadService: SøknadService,
+class BarnetrygdSøknadController(
+    private val barnetrygdSøknadService: BarnetrygdSøknadService,
 ) {
 
     // Metrics for ordinær barnetrygd
@@ -47,7 +47,8 @@ class SøknadController(
     val utvidetAntallDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.dokumentasjonsbehov.antall")
     val utvidetSøknadHarVedlegg = Metrics.counter("barnetrygd.soknad.utvidet.harVedlegg")
     val utvidetAntallVedlegg = Metrics.counter("barnetrygd.soknad.utvidet.harVedlegg.antall")
-    val utvidetHarManglerIDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.harManglerIDokumentasjonsbehov")
+    val utvidetHarManglerIDokumentasjonsbehov =
+        Metrics.counter("barnetrygd.soknad.utvidet.harManglerIDokumentasjonsbehov")
 
     // Metrics for EØS barnetrygd
     val ordinærSøknadEøs = Metrics.counter("barnetrygd.ordinaer.soknad.eos")
@@ -68,7 +69,7 @@ class SøknadController(
         }
 
         return try {
-            val dbSøknad = søknadService.motta(versjonertSøknad = versjonertSøknad)
+            val dbSøknad = barnetrygdSøknadService.motta(versjonertSøknad = versjonertSøknad)
             sendMetrics(versjonertSøknad = versjonertSøknad)
             ResponseEntity.ok(Ressurs.success(Kvittering("Søknad er mottatt", dbSøknad.opprettetTid)))
         } catch (e: FødselsnummerErNullException) {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadMetrikkService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadMetrikkService.kt
@@ -1,0 +1,129 @@
+package no.nav.familie.baks.mottak.søknad.barnetrygd
+
+import io.micrometer.core.instrument.Metrics
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV7
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertSøknad
+import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
+import no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknadsvedlegg
+import org.springframework.stereotype.Service
+
+@Service
+class BarnetrygdSøknadMetrikkService {
+
+    // Metrics for ordinær barnetrygd
+    private val søknadMottattOk = Metrics.counter("barnetrygd.soknad.mottatt.ok")
+    private val søknadMottattFeil = Metrics.counter("barnetrygd.soknad.mottatt.feil")
+    private val søknadHarDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.dokumentasjonsbehov")
+    private val antallDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.dokumentasjonsbehov.antall")
+    private val søknadHarVedlegg = Metrics.counter("barnetrygd.soknad.harVedlegg")
+    private val antallVedlegg = Metrics.counter("barnetrygd.soknad.harVedlegg.antall")
+    private val harManglerIDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.harManglerIDokumentasjonsbehov")
+
+    // Metrics for utvidet barnetrygd
+    private val søknadUtvidetMottattOk = Metrics.counter("barnetrygd.soknad.utvidet.mottatt.ok")
+    private val søknadUtvidetMottattFeil = Metrics.counter("barnetrygd.soknad.utvidet.mottatt.feil")
+    private val utvidetSøknadHarDokumentasjonsbehov = Metrics.counter("barnetrygd.soknad.utvidet.dokumentasjonsbehov")
+    private val utvidetAntallDokumentasjonsbehov =
+        Metrics.counter("barnetrygd.soknad.utvidet.dokumentasjonsbehov.antall")
+    private val utvidetSøknadHarVedlegg = Metrics.counter("barnetrygd.soknad.utvidet.harVedlegg")
+    private val utvidetAntallVedlegg = Metrics.counter("barnetrygd.soknad.utvidet.harVedlegg.antall")
+    private val utvidetHarManglerIDokumentasjonsbehov =
+        Metrics.counter("barnetrygd.soknad.utvidet.harManglerIDokumentasjonsbehov")
+
+    // Metrics for EØS barnetrygd
+    private val ordinærSøknadEøs = Metrics.counter("barnetrygd.ordinaer.soknad.eos")
+    private val utvidetSøknadEøs = Metrics.counter("barnetrygd.utvidet.soknad.eos")
+
+    fun sendMottakMetrikker(versjonertSøknad: VersjonertSøknad) {
+        val (søknadstype, dokumentasjon) = when (versjonertSøknad) {
+            is SøknadV7 -> Pair(versjonertSøknad.søknad.søknadstype, versjonertSøknad.søknad.dokumentasjon)
+            is SøknadV8 -> Pair(versjonertSøknad.søknad.søknadstype, versjonertSøknad.søknad.dokumentasjon)
+        }
+
+        val harEøsSteg = when (versjonertSøknad) {
+            is SøknadV7 -> versjonertSøknad.søknad.antallEøsSteg > 0
+            is SøknadV8 -> versjonertSøknad.søknad.antallEøsSteg > 0
+        }
+
+        val erUtvidet = søknadstype == Søknadstype.UTVIDET
+        sendSøknadMetrikker(harEøsSteg, erUtvidet)
+
+        sendDokumentasjonMetrikker(erUtvidet, dokumentasjon)
+    }
+
+    fun sendMottakFeiletMetrikker(versjonertSøknad: VersjonertSøknad) {
+        val søknadstype = when (versjonertSøknad) {
+            is SøknadV7 -> versjonertSøknad.søknad.søknadstype
+            is SøknadV8 -> versjonertSøknad.søknad.søknadstype
+        }
+        if (søknadstype == Søknadstype.UTVIDET) søknadUtvidetMottattFeil.increment() else søknadMottattFeil.increment()
+    }
+
+    private fun sendSøknadMetrikker(harEøsSteg: Boolean, erUtvidet: Boolean) {
+        if (erUtvidet) {
+            søknadUtvidetMottattOk.increment()
+            if (harEøsSteg) {
+                utvidetSøknadEøs.increment()
+            }
+        } else {
+            søknadMottattOk.increment()
+            if (harEøsSteg) {
+                ordinærSøknadEøs.increment()
+            }
+        }
+    }
+
+    private fun sendDokumentasjonMetrikker(erUtvidet: Boolean, dokumentasjon: List<Søknaddokumentasjon>) {
+        if (dokumentasjon.isNotEmpty()) {
+            // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
+            val dokumentasjonsbehovUtenAnnenDokumentasjon =
+                dokumentasjon.filter { it.dokumentasjonsbehov != Dokumentasjonsbehov.ANNEN_DOKUMENTASJON }
+
+            if (dokumentasjonsbehovUtenAnnenDokumentasjon.isNotEmpty()) {
+                sendDokumentasjonsbehovMetrikker(
+                    erUtvidet = erUtvidet,
+                    dokumentasjonsbehov = dokumentasjonsbehovUtenAnnenDokumentasjon,
+                )
+            }
+            // Inkluderer Dokumentasjonsbehov.ANNEN_DOKUMENTASJON for søknadHarVedlegg og antallVedlegg
+            val alleVedlegg: List<Søknadsvedlegg> = dokumentasjon.map { it.opplastedeVedlegg }.flatten()
+            if (alleVedlegg.isNotEmpty()) {
+                sendVedleggMetrikker(erUtvidet = erUtvidet, vedlegg = alleVedlegg)
+            }
+
+            // Filtrerer ut Dokumentasjonsbehov.ANNEN_DOKUMENTASJON
+            val harMangler =
+                dokumentasjonsbehovUtenAnnenDokumentasjon.any { !it.harSendtInn && it.opplastedeVedlegg.isEmpty() }
+            if (harMangler) {
+                sendManglerVedleggMetrikker(erUtvidet = erUtvidet)
+            }
+        }
+    }
+
+    private fun sendDokumentasjonsbehovMetrikker(erUtvidet: Boolean, dokumentasjonsbehov: List<Søknaddokumentasjon>) {
+        if (erUtvidet) {
+            utvidetSøknadHarDokumentasjonsbehov.increment()
+            utvidetAntallDokumentasjonsbehov.increment(dokumentasjonsbehov.size.toDouble())
+        } else {
+            søknadHarDokumentasjonsbehov.increment()
+            antallDokumentasjonsbehov.increment(dokumentasjonsbehov.size.toDouble())
+        }
+    }
+
+    private fun sendVedleggMetrikker(erUtvidet: Boolean, vedlegg: List<Søknadsvedlegg>) {
+        if (erUtvidet) {
+            utvidetSøknadHarVedlegg.increment()
+            utvidetAntallVedlegg.increment(vedlegg.size.toDouble())
+        } else {
+            søknadHarVedlegg.increment()
+            antallVedlegg.increment(vedlegg.size.toDouble())
+        }
+    }
+
+    private fun sendManglerVedleggMetrikker(erUtvidet: Boolean) {
+        if (erUtvidet) utvidetHarManglerIDokumentasjonsbehov.increment() else harManglerIDokumentasjonsbehov.increment()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadService.kt
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.Properties
 
 @Service
-class SøknadService(
+class BarnetrygdSøknadService(
     private val søknadRepository: SøknadRepository,
     private val vedleggRepository: SøknadVedleggRepository,
     private val taskService: TaskService,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadMetrikkService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadMetrikkService.kt
@@ -1,0 +1,81 @@
+package no.nav.familie.baks.mottak.søknad.kontantstøtte
+
+import io.micrometer.core.instrument.Metrics
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV3
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
+import no.nav.familie.kontrakter.ks.søknad.v1.Dokumentasjonsbehov
+import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
+import org.springframework.stereotype.Service
+
+@Service
+class KontantstøtteSøknadMetrikkService {
+
+    // Metrics for kontantstotte
+    val søknadMottattOk = Metrics.counter("kontantstotte.soknad.mottatt.ok")
+    val søknadMottattFeil = Metrics.counter("kontantstotte.soknad.mottatt.feil")
+    val søknadHarDokumentasjonsbehov = Metrics.counter("kontantstotte.soknad.dokumentasjonsbehov")
+    val antallDokumentasjonsbehov = Metrics.counter("kontantstotte.soknad.dokumentasjonsbehov.antall")
+    val søknadHarVedlegg = Metrics.counter("kontantstotte.soknad.harVedlegg")
+    val antallVedlegg = Metrics.counter("kontantstotte.soknad.harVedlegg.antall")
+    val harManglerIDokumentasjonsbehov = Metrics.counter("kontantstotte.soknad.harManglerIDokumentasjonsbehov")
+
+    // Metrics for EØS kontantstotte
+    val søknadEøs = Metrics.counter("kontantstotte.soknad.eos")
+
+    fun sendMottakMetrikker(versjonertKontantstøtteSøknad: VersjonertKontantstøtteSøknad) {
+        val dokumentasjon = when (versjonertKontantstøtteSøknad) {
+            is KontantstøtteSøknadV3 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.dokumentasjon
+            is KontantstøtteSøknadV4 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.dokumentasjon
+        }
+
+        val harEøsSteg = when (versjonertKontantstøtteSøknad) {
+            is KontantstøtteSøknadV3 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.antallEøsSteg > 0
+            is KontantstøtteSøknadV4 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.antallEøsSteg > 0
+        }
+
+        sendSøknadMetrikker(harEøsSteg)
+
+        sendDokumentasjonMetrikker(dokumentasjon)
+    }
+
+    fun sendMottakFeiletMetrikker() {
+        søknadMottattFeil.increment()
+    }
+
+    private fun sendSøknadMetrikker(harEøsSteg: Boolean) {
+        søknadMottattOk.increment()
+        if (harEøsSteg) {
+            søknadEøs.increment()
+        }
+    }
+
+    private fun sendDokumentasjonMetrikker(dokumentasjon: List<Søknaddokumentasjon>) {
+        if (dokumentasjon.isNotEmpty()) {
+            val dokumentasjonsbehovUtenAnnenDokumentasjon =
+                dokumentasjon.filter { it.dokumentasjonsbehov != Dokumentasjonsbehov.ANNEN_DOKUMENTASJON }
+
+            if (dokumentasjonsbehovUtenAnnenDokumentasjon.isNotEmpty()) {
+                sendDokumentasjonsbehovMetrikker(
+                    dokumentasjonsbehov = dokumentasjonsbehovUtenAnnenDokumentasjon,
+                )
+            }
+            val alleVedlegg = dokumentasjon.map { it.opplastedeVedlegg }.flatten()
+            if (alleVedlegg.isNotEmpty()) {
+                søknadHarVedlegg.increment()
+                antallVedlegg.increment(alleVedlegg.size.toDouble())
+            }
+
+            val harMangler =
+                dokumentasjonsbehovUtenAnnenDokumentasjon.any { !it.harSendtInn && it.opplastedeVedlegg.isEmpty() }
+            if (harMangler) {
+                harManglerIDokumentasjonsbehov.increment()
+            }
+        }
+    }
+
+    private fun sendDokumentasjonsbehovMetrikker(dokumentasjonsbehov: List<Søknaddokumentasjon>) {
+        søknadHarDokumentasjonsbehov.increment()
+        antallDokumentasjonsbehov.increment(dokumentasjonsbehov.size.toDouble())
+    }
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadService.kt
@@ -100,5 +100,4 @@ class KontantstøtteSøknadService(
             }
         }
     }
-
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadService.kt
@@ -100,4 +100,5 @@ class KontantstøtteSøknadService(
             }
         }
     }
+
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/EksternReferanseIdTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/EksternReferanseIdTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.DevLauncherPostgres
-import no.nav.familie.baks.mottak.søknad.barnetrygd.SøknadService
+import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
 import no.nav.familie.baks.mottak.task.JournalførSøknadTask
 import no.nav.familie.baks.mottak.util.DbContainerInitializer
@@ -24,7 +24,7 @@ import java.util.Properties
 @SpringBootTest(classes = [DevLauncherPostgres::class])
 class EksternReferanseIdTest(
     @Autowired
-    val søknadService: SøknadService,
+    val barnetrygdSøknadService: BarnetrygdSøknadService,
     @Autowired
     val journalførSøknadTask: JournalførSøknadTask,
 ) {
@@ -34,7 +34,7 @@ class EksternReferanseIdTest(
 
     @Test
     fun `ved (409 Conflict) fra dokarkiv skal HttpClientErrorException Conflict catches og håndteres i task'en`() {
-        val dbSøknadFraDBFirst = søknadService.lagreDBSøknad(dbSøknad.copy(journalpostId = null))
+        val dbSøknadFraDBFirst = barnetrygdSøknadService.lagreDBSøknad(dbSøknad.copy(journalpostId = null))
         val properties = Properties().apply { this["søkersFødselsnummer"] = dbSøknadFraDBFirst.fnr }
 
         assertDoesNotThrow {

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/JournalføringTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/JournalføringTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.baks.mottak.søknad
 
 import io.mockk.junit5.MockKExtension
 import no.nav.familie.baks.mottak.DevLauncherPostgres
-import no.nav.familie.baks.mottak.søknad.barnetrygd.SøknadService
+import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadTestData
@@ -27,7 +27,7 @@ class JournalføringTest(
     @Autowired
     val journalføringService: JournalføringService,
     @Autowired
-    val søknadService: SøknadService,
+    val barnetrygdSøknadService: BarnetrygdSøknadService,
     @Autowired
     val kontantstøtteSøknadService: KontantstøtteSøknadService,
 ) {
@@ -68,10 +68,10 @@ class JournalføringTest(
 
     @Test
     fun `journalPostId blir lagt på dbSøknaden`() {
-        val dbSøknadFraDB = søknadService.lagreDBSøknad(dbSøknad)
+        val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknad)
         assertEquals(null, dbSøknadFraDB.journalpostId)
         journalføringService.journalførBarnetrygdSøknad(dbSøknadFraDB, testPDF)
-        val overskrevetDBSøknad = søknadService.hentDBSøknad(dbSøknadFraDB.id)
+        val overskrevetDBSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
 
         assertEquals("123", overskrevetDBSøknad!!.journalpostId)
     }
@@ -90,10 +90,10 @@ class JournalføringTest(
     @Test
     fun `journalPostId skal ikke bli satt hvis den allerede finnes på dbSøknad`() {
         val dbSøknadMedJournalpostId = dbSøknad.copy(journalpostId = "1")
-        val dbSøknadFraDB = søknadService.lagreDBSøknad(dbSøknadMedJournalpostId)
+        val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadMedJournalpostId)
 
         journalføringService.journalførBarnetrygdSøknad(dbSøknadFraDB, testPDF)
-        val ikkeOverskrevetDBSøknad = søknadService.hentDBSøknad(dbSøknadFraDB.id)
+        val ikkeOverskrevetDBSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
 
         assertEquals("1", ikkeOverskrevetDBSøknad!!.journalpostId)
     }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.DevLauncherPostgres
-import no.nav.familie.baks.mottak.søknad.barnetrygd.SøknadService
+import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV7
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
@@ -25,7 +25,7 @@ import kotlin.test.assertEquals
 @Tag("integration")
 @SpringBootTest(classes = [DevLauncherPostgres::class])
 class SøknadTest(
-    @Autowired val søknadService: SøknadService,
+    @Autowired val barnetrygdSøknadService: BarnetrygdSøknadService,
 ) {
 
     val søknadV8 = SøknadTestData.søknadV8()
@@ -35,8 +35,8 @@ class SøknadTest(
         val dbSøknadFraMapper = søknadV8.tilDBSøknad()
         assertThat(dbSøknadFraMapper.hentVersjonertSøknad() is SøknadV8).isTrue
 
-        val dbSøknadFraDB = søknadService.lagreDBSøknad(dbSøknadFraMapper)
-        val hentetSøknad = søknadService.hentDBSøknad(dbSøknadFraDB.id)
+        val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadFraMapper)
+        val hentetSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
         assertEquals(dbSøknadFraDB.id, hentetSøknad!!.id)
         assertThat(hentetSøknad.hentVersjonertSøknad() is SøknadV8)
     }
@@ -53,8 +53,8 @@ class SøknadTest(
         }
         assertEquals(søknadV8.kontraktVersjon, versjon)
 
-        val dbSøknadFraDB = søknadService.lagreDBSøknad(dbSøknadFraMapper)
-        val hentetSøknad = søknadService.hentDBSøknad(dbSøknadFraDB.id)
+        val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadFraMapper)
+        val hentetSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
         assertEquals(dbSøknadFraDB.id, hentetSøknad!!.id)
         assertThat(hentetSøknad.hentVersjonertSøknad() is SøknadV8).isTrue
     }


### PR DESCRIPTION
* Renamet `SøknadController` og `SøknadService` til `BarnetrygdSøknadController` og `BarnetrygdSøknadService`
* Flyttet logikk for søknads-metrikker ut av controller og inn i egne servicer. 
* Ingen endring av logikk, kun renaming og flytting av kode