### PR TITLE
GitHub token permissions Monitor action

### DIFF
--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -13,9 +13,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -55,7 +52,7 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -DskipTests -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
 
       - uses: nais/docker-build-push@v0
         id: docker-push

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -DskipTests  -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
 
       - uses: nais/docker-build-push@v0
         id: docker-push

--- a/.github/workflows/build-and-deploy-preprod.yml
+++ b/.github/workflows/build-and-deploy-preprod.yml
@@ -13,6 +13,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -36,6 +39,9 @@ jobs:
       id-token: "write"
       packages: write
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v3
         with:
           persist-credentials: false


### PR DESCRIPTION
https://nav-it.slack.com/archives/C60FFACN5/p1688371686624429
Vi endrer default permissions for GITHUB_TOKEN i navikt-orgen til “read” fom 1 september. Dette bringer oss inn i en mere “fine grained” tilgangsmodell, og gjør oss litt mindre sårbare for angrep via ting som ondsinnede actions og NPM-pakker eller andre ting som kan kjøre kode i workflowene. Hvis jobbene dine bare sjekker ut og bygger vil du sannsynligvis ikke merke noe. De jobbene som trenger å skrive informasjon tilbake i en eller annen form (releases, issues, packages mm) må gis disse tilgangene [eksplisitt](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) ved å legge til en “permissions”-del i jobben. GitHub har laget et [verktøy](https://github.blog/2023-06-26-new-tool-to-secure-your-github-actions/) som gjør det enklere for å finne ut hvilke permissions dine workflows faktisk trenger. Endringene i workflowene kan iverksettes allerede nå.