### PR TITLE
Ikke send duplikate hendelser ved merge

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/IdenthendelseV2Consumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/IdenthendelseV2Consumer.kt
@@ -65,7 +65,7 @@ class IdenthendelseV2Consumer(
                     sakClient.sendIdenthendelseTilSak(PersonIdent(ident = folkeregisterident.idnummer.toString()))
                 }
             } else {
-                SECURE_LOGGER.info("Ignorerer å sende ident-hendelse til ba-sak for aktør $aktørIdPåHendelse ikke lenger gyldig aktø")
+                SECURE_LOGGER.info("Ignorerer å sende ident-hendelse til ba-sak for aktør $aktørIdPåHendelse ikke lenger gyldig aktør")
             }
         } catch (e: RuntimeException) {
             identhendelseFeiletCounter.increment()

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/IdenthendelseV2Consumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/IdenthendelseV2Consumer.kt
@@ -45,18 +45,27 @@ class IdenthendelseV2Consumer(
             SECURE_LOGGER.info("Har mottatt ident-hendelse $consumerRecord")
 
             val aktør = consumerRecord.value()
+            val aktørIdPåHendelse = consumerRecord.key()
 
             if (aktør == null) {
                 log.warn("Tom aktør fra identhendelse")
-                SECURE_LOGGER.warn("Tom aktør fra identhendelse med nøkkel ${consumerRecord.key()}")
+                SECURE_LOGGER.warn("Tom aktør fra identhendelse med nøkkel $aktørIdPåHendelse")
             }
 
-            aktør?.identifikatorer?.singleOrNull { ident ->
-                ident.type == Type.FOLKEREGISTERIDENT && ident.gjeldende
-            }?.also { folkeregisterident ->
-                SECURE_LOGGER.info("Sender ident-hendelse til ba-sak for ident $folkeregisterident")
+            val aktivAktørid = aktør?.identifikatorer?.singleOrNull { ident ->
+                ident.type == Type.AKTORID && ident.gjeldende
+            }?.idnummer.toString()
 
-                sakClient.sendIdenthendelseTilSak(PersonIdent(ident = folkeregisterident.idnummer.toString()))
+            if (aktørIdPåHendelse == aktivAktørid) { // I tilfeller som ved merge av hendelser vil man få både identhendelse på gammel og ny aktørid, så for å unngå duplikater så sender man bare på aktiv ident
+                aktør?.identifikatorer?.singleOrNull { ident ->
+                    ident.type == Type.FOLKEREGISTERIDENT && ident.gjeldende
+                }?.also { folkeregisterident ->
+                    SECURE_LOGGER.info("Sender ident-hendelse til ba-sak for ident $folkeregisterident")
+
+                    sakClient.sendIdenthendelseTilSak(PersonIdent(ident = folkeregisterident.idnummer.toString()))
+                }
+            } else {
+                SECURE_LOGGER.info("Ignorerer å sende ident-hendelse til ba-sak for aktør $aktørIdPåHendelse ikke lenger gyldig aktø")
             }
         } catch (e: RuntimeException) {
             identhendelseFeiletCounter.increment()


### PR DESCRIPTION
Ved merge kan det komme inn 2 hendelser, siden 2 identer med hver sin aktøriId blir slått sammen, og det vi da generes 2 hendelser på topic. Både på aktiv aktørId og deaktivert aktørId. Siden vi slår opp gjeldene fnr og sender fnr til sak, så filtrerer man bort den deaktiverte aktørId for å unngå duplikate meldinger til sak.

