### PR TITLE
Filterer vekk hendelser hvor man ikke finner identen i pdl

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseService.kt
@@ -63,6 +63,12 @@ class VurderLivshendelseService(
         val personIdent = payload.personIdent
         val type = payload.type
 
+        if (pdlClient.hentIdenter(personIdent = personIdent, tema).isEmpty()) {
+            log.warn("Hendelse ignoreres siden ident ikke eksisterer")
+            secureLog.warn("Hendelse ignoreres siden ident ikke eksisterer for $personIdent")
+            return
+        }
+
         when (type) {
             VurderLivshendelseType.DØDSFALL -> {
                 secureLog.info("Har mottatt dødsfallshendelse for person $personIdent")


### PR DESCRIPTION
I det siste har man fått flere hendelser fra pdl hvor ident ikke finnes i PDL. Disse kan ikke ha fagsak, så filtererer de bort for å redusere støy. Slik som de som er avvikshåndtert i baks-mottak
https://familie-prosessering.intern.nav.no/service/familie-baks-mottak?statusFilter=AVVIKSH%C3%85NDTERT&side=0&taskType=