### PR TITLE
Fikser det slik at pdl kaster PdlNotFoundException hvis ident ikke eksisterer, slik at man kan catche disse og ignorere hendelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/IntegrasjonException.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/IntegrasjonException.kt
@@ -7,7 +7,7 @@ import org.springframework.web.client.RestClientResponseException
 import java.net.URI
 
 @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
-class IntegrasjonException(
+open class IntegrasjonException(
     msg: String,
     throwable: Throwable? = null,
     uri: URI? = null,
@@ -40,3 +40,9 @@ class IntegrasjonException(
         }
     }
 }
+
+class PdlNotFoundException(
+    msg: String,
+    uri: URI,
+    ident: String,
+) : IntegrasjonException(msg = msg, uri = uri, ident = ident)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/PdlClient.kt
@@ -40,6 +40,14 @@ class PdlClient(
         val response = postForEntity<PdlHentIdenterResponse>(pdlUri, pdlPersonRequest, httpHeaders(tema))
 
         if (response.harFeil()) {
+            if (response.errors?.any { it.extensions?.notFound() == true } == true) {
+                throw PdlNotFoundException(
+                    msg = "Fant ikke identer på person: ${response.errorMessages()}",
+                    uri = pdlUri,
+                    ident = personIdent,
+                )
+            }
+
             throw IntegrasjonException(
                 msg = "Fant ikke identer på person: ${response.errorMessages()}",
                 uri = pdlUri,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.baks.mottak.integrasjoner.KsSakClient
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveClient
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveVurderLivshendelseDto
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.baks.mottak.integrasjoner.PdlNotFoundException
 import no.nav.familie.baks.mottak.integrasjoner.PdlPersonData
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsakIdOgTilknyttetAktørId
 import no.nav.familie.baks.mottak.integrasjoner.RestMinimalFagsak
@@ -63,7 +64,9 @@ class VurderLivshendelseService(
         val personIdent = payload.personIdent
         val type = payload.type
 
-        if (pdlClient.hentIdenter(personIdent = personIdent, tema).isEmpty()) {
+        try {
+            pdlClient.hentIdenter(personIdent = personIdent, tema)
+        } catch (e: PdlNotFoundException) {
             log.warn("Hendelse ignoreres siden ident ikke eksisterer")
             secureLog.warn("Hendelse ignoreres siden ident ikke eksisterer for $personIdent")
             return

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.baks.mottak.integrasjoner.OppgaveClient
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveVurderLivshendelseDto
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlForeldreBarnRelasjon
+import no.nav.familie.baks.mottak.integrasjoner.PdlNotFoundException
 import no.nav.familie.baks.mottak.integrasjoner.PdlPersonData
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsakDeltager
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsakIdOgTilknyttetAktørId
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Year
@@ -611,6 +613,7 @@ class VurderLivshendelseServiceTest {
 
     @Test
     fun `Skal ignorere hendelse hvis ident ikke finnes i PDL`() {
+        every { mockPdlClient.hentIdenter(UKJENT_PERSONIDENT, any()) } throws PdlNotFoundException("fant ikke ident", URI.create("mocked"), UKJENT_PERSONIDENT)
         val livshendelseTask =
             Task(
                 type = VurderKontantstøtteLivshendelseTask.TASK_STEP_TYPE,
@@ -625,7 +628,6 @@ class VurderLivshendelseServiceTest {
 
         vurderLivshendelseService.vurderLivshendelseOppgave(livshendelseTask, Tema.BAR)
 
-        val oppgaveSlot = mutableListOf<OppgaveVurderLivshendelseDto>()
         verify(exactly = 0) {
             mockOppgaveClient.opprettVurderLivshendelseOppgave(any())
             mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any())


### PR DESCRIPTION
Fikser feil i 
https://github.com/navikt/familie-baks-mottak/pull/1016

Tjenesten kaster feil og ikke tom liste hvis ident ikke finnes. Skrevet om til at pdlClient kaster egen feil hvis not_found og catcher denne og ignorerer hendelsen.