### PR TITLE
Bump felles.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <kontrakter.version>3.0_20240215101759_cea211f</kontrakter.version>
         <main-class>no.nav.familie.baks.mottak.LauncherKt</main-class>
         <spring.cloud.version>4.1.1</spring.cloud.version>
-        <token-validation-spring.version>3.2.0</token-validation-spring.version>
+        <token-validation-spring.version>4.1.3</token-validation-spring.version>
         <avro.version>1.11.3</avro.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
@@ -139,6 +139,11 @@
         <dependency>
             <groupId>no.nav.security</groupId>
             <artifactId>token-client-spring</artifactId>
+            <version>${token-validation-spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.security</groupId>
+            <artifactId>token-validation-core</artifactId>
             <version>${token-validation-spring.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <confluent.version>7.6.0</confluent.version>
         <prosessering.version>2.20240214140223_83c31de</prosessering.version>
 
-        <felles.version>2.20240123084817_35f03aa</felles.version>
+        <felles.version>2.20240221144438_022879d_token-support-4</felles.version>
         <kontrakter.version>3.0_20240215101759_cea211f</kontrakter.version>
         <main-class>no.nav.familie.baks.mottak.LauncherKt</main-class>
         <spring.cloud.version>4.1.1</spring.cloud.version>

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,12 +3,10 @@ no.nav.security.jwt:
     selvbetjening:
       discoveryurl: http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
       accepted_audience: aud-localhost
-      cookie_name: localhost-idtoken
     # Kommenteres ut ved lokal testing av innsending av søknad
   #    azuread:
   #      discoveryurl: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
   #      accepted_audience: ${CLIENT_ID}
-  #      cookie_name: azure_token
   client:
     registration:
       ba-sak-clientcredentials:

--- a/src/main/resources/application-postgres.yaml
+++ b/src/main/resources/application-postgres.yaml
@@ -3,12 +3,10 @@ no.nav.security.jwt:
     selvbetjening:
       discoveryurl: http://localhost:${mock-oauth2-server.port}/selvbetjening/.well-known/openid-configuration
       accepted_audience: aud-localhost
-      cookie_name: localhost-idtoken
       # Kommenteres ut ved lokal testing av innsending av søknad
     #    azuread:
     #      discoveryurl: https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration
     #      accepted_audience: ${CLIENT_ID}
-    #      cookie_name: azure_token
 
   client:
     registration:

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -2,7 +2,6 @@ no.nav.security.jwt:
   issuer.azuread:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
     accepted_audience: ${AZURE_APP_CLIENT_ID}
-    cookie_name: azure_token
   issuer.tokenx:
     discoveryurl: ${TOKEN_X_WELL_KNOWN_URL}
     accepted_audience: ${TOKEN_X_CLIENT_ID}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -2,7 +2,6 @@ no.nav.security.jwt:
   issuer.azuread:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
     accepted_audience: ${AZURE_APP_CLIENT_ID}
-    cookie_name: azure_token
   issuer.tokenx:
     discoveryurl: ${TOKEN_X_WELL_KNOWN_URL}
     accepted_audience: ${TOKEN_X_CLIENT_ID}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/config/OAuth2AccessTokenTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/config/OAuth2AccessTokenTestConfig.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.baks.mottak.config
 
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -14,11 +14,10 @@ import org.springframework.context.annotation.Profile
 class OAuth2AccessTokenTestConfig {
     @Bean
     @Primary
-    fun oAuth2AccessTokenServiceMock(): OAuth2AccessTokenService? {
-        val tokenMockService =
-            Mockito.mock(OAuth2AccessTokenService::class.java)
-        Mockito.`when`(tokenMockService.getAccessToken(ArgumentMatchers.any()))
-            .thenReturn(OAuth2AccessTokenResponse("Mock-token-response", 60, 60, null))
+    fun oAuth2AccessTokenServiceMock(): OAuth2AccessTokenService {
+        val tokenMockService = mockk<OAuth2AccessTokenService>()
+        every { tokenMockService.getAccessToken(any()) } returns OAuth2AccessTokenResponse("Mock-token-response", 60, 60, emptyMap())
+
         return tokenMockService
     }
 }


### PR DESCRIPTION
Bumps `felles.version` from 2.20240123084817_35f03aa to 2.20240221144438_022879d_token-support-4.

Updates `no.nav.familie.felles:log` from 2.20240123084817_35f03aa to 2.20240221144438_022879d_token-support-4
- [Commits](https://github.com/navikt/familie-felles/commits)

Updates `no.nav.familie.felles:http-client` from 2.20240123084817_35f03aa to 2.20240221144438_022879d_token-support-4
- [Commits](https://github.com/navikt/familie-felles/commits)

Updates `no.nav.familie.felles:leader` from 2.20240123084817_35f03aa to 2.20240221144438_022879d_token-support-4
- [Commits](https://github.com/navikt/familie-felles/commits)

---
updated-dependencies:
- dependency-name: no.nav.familie.felles:log
  dependency-type: direct:production
- dependency-name: no.nav.familie.felles:http-client
  dependency-type: direct:production
- dependency-name: no.nav.familie.felles:leader
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>