### PR TITLE
Fikser journalhendelseRuting-tasker som feiler

### DIFF
--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/NavnoHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/NavnoHendelseTaskLøypeTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.baks.mottak.integrasjoner.Bruker
 import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
 import no.nav.familie.baks.mottak.integrasjoner.FagsakDeltagerRolle.FORELDER
 import no.nav.familie.baks.mottak.integrasjoner.FagsakStatus.LØPENDE
+import no.nav.familie.baks.mottak.integrasjoner.IdentInformasjon
 import no.nav.familie.baks.mottak.integrasjoner.InfotrygdBarnetrygdClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalpost
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
@@ -93,6 +94,10 @@ class NavnoHendelseTaskLøypeTest {
         every {
             mockInfotrygdBarnetrygdClient.hentSaker(any(), any())
         } returns InfotrygdSøkResponse(emptyList(), emptyList())
+
+        every {
+            mockPdlClient.hentIdenter(any(), any())
+        } returns listOf(IdentInformasjon("12345678910", historisk = false, gruppe = "FOLKEREGISTERIDENT"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/SkanHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/SkanHendelseTaskLøypeTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
 import no.nav.familie.baks.mottak.integrasjoner.FagsakDeltagerRolle.BARN
 import no.nav.familie.baks.mottak.integrasjoner.FagsakDeltagerRolle.FORELDER
 import no.nav.familie.baks.mottak.integrasjoner.FagsakStatus.LØPENDE
+import no.nav.familie.baks.mottak.integrasjoner.IdentInformasjon
 import no.nav.familie.baks.mottak.integrasjoner.InfotrygdBarnetrygdClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalpost
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
@@ -85,6 +86,10 @@ class SkanHendelseTaskLøypeTest {
         every {
             mockPdlClient.hentPersonident(any(), any())
         } returns "12345678910"
+
+        every {
+            mockPdlClient.hentIdenter(any(), any())
+        } returns listOf(IdentInformasjon("12345678910", historisk = false, gruppe = "FOLKEREGISTERIDENT"))
 
         every {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())


### PR DESCRIPTION
 pga. ba-sak ikke lenger håndterer aktørId'er som personident i kallet til /sok/fagsakdeltagere