### PR TITLE
Rapporter status for søknadsmottak til statusplattform og produksjonslogg

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -50,6 +50,8 @@ spec:
         - application: familie-prosessering
           namespace: teamfamilie
           cluster: dev-gcp
+        - application: statuspoll
+          namespace: navdig
     outbound:
       rules:
         - application: familie-ba-sak

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -50,6 +50,8 @@ spec:
         - application: familie-prosessering
           namespace: teamfamilie
           cluster: prod-gcp
+        - application: statuspoll
+          namespace: navdig
     outbound:
       rules:
         - application: familie-ba-sak

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
@@ -1,0 +1,76 @@
+package no.nav.familie.baks.mottak.søknad
+
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
+import no.nav.security.token.support.core.api.Unprotected
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping(path = ["/api/status"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class StatusController(val barnetrygdSøknadRepository: SøknadRepository) {
+
+    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    @GetMapping()
+    @Unprotected
+    fun status(): StatusDto {
+        val sistBarnetrygdSøknad = barnetrygdSøknadRepository.finnSisteLagredeSøknad()
+        val tidSidenSisteBarnetrygdSøknad = Duration.between(LocalDateTime.now(), sistBarnetrygdSøknad.opprettetTid)
+        loggHvisLiteAktivitet(tidSidenSisteBarnetrygdSøknad)
+        return lagStatusDto(tidSidenSisteBarnetrygdSøknad)
+    }
+
+    private fun loggHvisLiteAktivitet(tidSidenSisteLagredeSøknad: Duration) {
+        if (erDagtid() && !erHelg()) {
+            when {
+                tidSidenSisteLagredeSøknad.toHours() > 3 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteLagredeSøknad.toHours()} timer siden vi sist mottok en søknad")
+                tidSidenSisteLagredeSøknad.toMinutes() > 20 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteLagredeSøknad.toMinutes()} minutter siden vi sist mottok en søknad")
+            }
+        }
+    }
+
+    private fun lagStatusDto(tidSidenSisteLagredeSøknad: Duration) = when {
+        erTidspunktMedForventetAktivitet() -> lagDagStatus(tidSidenSisteLagredeSøknad)
+        else -> lagNattStatus(tidSidenSisteLagredeSøknad)
+    }
+
+    private fun lagDagStatus(tidSidenSisteLagredeSøknad: Duration) =
+        when {
+            tidSidenSisteLagredeSøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.DOWN,
+                description = "Det er over 12 timer siden sist vi mottok en søknad",
+            )
+            else -> StatusDto(status = Plattformstatus.OK, description = "Alt er OK", logLink = null)
+        }
+
+    private fun lagNattStatus(tidSidenSisteLagredeSøknad: Duration) =
+        when {
+            tidSidenSisteLagredeSøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.ISSUE,
+                description = "Det er over 12 timer siden sist vi mottok en søknad",
+            )
+            tidSidenSisteLagredeSøknad.toHours() > 24 -> StatusDto(
+                status = Plattformstatus.DOWN,
+                description = "Det er over 24 timer siden sist vi mottok en søknad",
+            )
+            else -> StatusDto(status = Plattformstatus.OK, description = "Alt er OK", logLink = null)
+        }
+
+
+    private fun erHelg() = LocalDateTime.now().dayOfWeek.value in 6..7
+    private fun erDagtid() = LocalDateTime.now().hour in 9..22
+    private fun erTidspunktMedForventetAktivitet() = LocalDateTime.now().hour in 12..21
+}
+
+
+const val LOG_URL = "https://logs.adeo.no/app/r/s/OJZqp"
+data class StatusDto(val status: Plattformstatus, val description: String? = null, val logLink: String? = LOG_URL)
+
+enum class Plattformstatus {
+    OK, ISSUE, DOWN
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
@@ -37,7 +37,7 @@ class StatusController(val barnetrygdSøknadRepository: SøknadRepository, val k
 
     private fun loggHvisLiteAktivitet(
         tidSidenSisteSøknad: Duration,
-        søknadstype: Søknadstype
+        søknadstype: Søknadstype,
     ) {
         if (erDagtid() && !erHelg()) {
             when {
@@ -49,7 +49,7 @@ class StatusController(val barnetrygdSøknadRepository: SøknadRepository, val k
 
     private fun lagStatusDto(
         tidSidenSisteSøknad: Duration,
-        søknadstype: Søknadstype
+        søknadstype: Søknadstype,
     ) =
         when {
             erTidspunktMedForventetAktivitet() -> lagDagStatus(tidSidenSisteSøknad, søknadstype)
@@ -58,7 +58,7 @@ class StatusController(val barnetrygdSøknadRepository: SøknadRepository, val k
 
     private fun lagDagStatus(
         tidSidenSisteSøknad: Duration,
-        søknadstype: Søknadstype
+        søknadstype: Søknadstype,
     ) =
         when {
             tidSidenSisteSøknad.toHours() > 12 ->
@@ -71,7 +71,7 @@ class StatusController(val barnetrygdSøknadRepository: SøknadRepository, val k
 
     private fun lagNattStatus(
         tidSidenSisteSøknad: Duration,
-        søknadstype: Søknadstype
+        søknadstype: Søknadstype,
     ) =
         when {
             tidSidenSisteSøknad.toHours() > 24 ->

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -13,50 +14,80 @@ import java.time.LocalDateTime
 
 @RestController
 @RequestMapping(path = ["/api/status"], produces = [MediaType.APPLICATION_JSON_VALUE])
-class StatusController(val barnetrygdSøknadRepository: SøknadRepository) {
+class StatusController(val barnetrygdSøknadRepository: SøknadRepository, val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository) {
 
     val logger: Logger = LoggerFactory.getLogger(javaClass)
     @GetMapping()
     @Unprotected
     fun status(): StatusDto {
         val sistBarnetrygdSøknad = barnetrygdSøknadRepository.finnSisteLagredeSøknad()
+        val sistKontantstøtteSøknad = kontantstøtteSøknadRepository.finnSisteLagredeSøknad()
         val tidSidenSisteBarnetrygdSøknad = Duration.between(LocalDateTime.now(), sistBarnetrygdSøknad.opprettetTid)
-        loggHvisLiteAktivitet(tidSidenSisteBarnetrygdSøknad)
-        return lagStatusDto(tidSidenSisteBarnetrygdSøknad)
+        val tidSidenSisteKontantstøtteSøknad = Duration.between(LocalDateTime.now(), sistKontantstøtteSøknad.opprettetTid)
+        loggHvisLiteAktivitet(tidSidenSisteBarnetrygdSøknad, tidSidenSisteKontantstøtteSøknad)
+        return lagStatusDto(tidSidenSisteBarnetrygdSøknad, tidSidenSisteKontantstøtteSøknad)
     }
 
-    private fun loggHvisLiteAktivitet(tidSidenSisteLagredeSøknad: Duration) {
+    private fun loggHvisLiteAktivitet(tidSidenSisteBASøknad: Duration, tidSidenSisteKSSøknad: Duration) {
         if (erDagtid() && !erHelg()) {
             when {
-                tidSidenSisteLagredeSøknad.toHours() > 3 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteLagredeSøknad.toHours()} timer siden vi sist mottok en søknad")
-                tidSidenSisteLagredeSøknad.toMinutes() > 20 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteLagredeSøknad.toMinutes()} minutter siden vi sist mottok en søknad")
+                tidSidenSisteBASøknad.toHours() > 3 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteBASøknad.toHours()} timer siden vi sist mottok en barnetrygdsøknad")
+                tidSidenSisteBASøknad.toMinutes() > 20 -> logger.warn("Status baks-mottak: Det er ${tidSidenSisteBASøknad.toMinutes()} minutter siden vi sist mottok en barnetrygdsøknad")
+            }
+            when {
+                tidSidenSisteKSSøknad.toHours() > 3 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteKSSøknad.toHours()} timer siden vi sist mottok en kontantstøttesøknad")
+                tidSidenSisteKSSøknad.toMinutes() > 20 -> logger.warn("Status baks-mottak: Det er ${tidSidenSisteKSSøknad.toMinutes()} minutter siden vi sist mottok en kontantstøttesøknad")
             }
         }
     }
 
-    private fun lagStatusDto(tidSidenSisteLagredeSøknad: Duration) = when {
-        erTidspunktMedForventetAktivitet() -> lagDagStatus(tidSidenSisteLagredeSøknad)
-        else -> lagNattStatus(tidSidenSisteLagredeSøknad)
+    private fun lagStatusDto(tidSidenSisteBASøknad: Duration, tidSidenSisteKSSøknad: Duration) = when {
+        erTidspunktMedForventetAktivitet() -> lagDagStatus(tidSidenSisteBASøknad, tidSidenSisteKSSøknad)
+        else -> lagNattStatus(tidSidenSisteBASøknad, tidSidenSisteKSSøknad)
     }
 
-    private fun lagDagStatus(tidSidenSisteLagredeSøknad: Duration) =
+    private fun lagDagStatus(tidSidenSisteBASøknad: Duration, tidSidenSisteKSSøknad: Duration) =
         when {
-            tidSidenSisteLagredeSøknad.toHours() > 12 -> StatusDto(
+            tidSidenSisteBASøknad.toHours() > 12 && tidSidenSisteKSSøknad.toHours() > 12 -> StatusDto(
                 status = Plattformstatus.DOWN,
-                description = "Det er over 12 timer siden sist vi mottok en søknad",
+                description = "Det er over 12 timer siden sist vi mottok en søknad om barnetrygd eller kontantstøtte",
+            )
+            tidSidenSisteBASøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.DOWN,
+                description = "Det er over 12 timer siden sist vi mottok en søknad om barnetrygd",
+            )
+            tidSidenSisteKSSøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.DOWN,
+                description = "Det er over 12 timer siden sist vi mottok en søknad om kontantstøtte",
             )
             else -> StatusDto(status = Plattformstatus.OK, description = "Alt er OK", logLink = null)
         }
 
-    private fun lagNattStatus(tidSidenSisteLagredeSøknad: Duration) =
+    private fun lagNattStatus(tidSidenSisteBASøknad: Duration, tidSidenSisteKSSøknad: Duration) =
         when {
-            tidSidenSisteLagredeSøknad.toHours() > 12 -> StatusDto(
-                status = Plattformstatus.ISSUE,
-                description = "Det er over 12 timer siden sist vi mottok en søknad",
-            )
-            tidSidenSisteLagredeSøknad.toHours() > 24 -> StatusDto(
+            tidSidenSisteBASøknad.toHours() > 24 && tidSidenSisteKSSøknad.toHours() > 24 -> StatusDto(
                 status = Plattformstatus.DOWN,
-                description = "Det er over 24 timer siden sist vi mottok en søknad",
+                description = "Det er over 24 timer siden sist vi mottok en søknad om barnetrygd eller kontantstøtte",
+            )
+            tidSidenSisteBASøknad.toHours() > 24 -> StatusDto(
+                status = Plattformstatus.DOWN,
+                description = "Det er over 24 timer siden sist vi mottok en søknad om barnetrygd",
+            )
+            tidSidenSisteKSSøknad.toHours() > 24 -> StatusDto(
+                status = Plattformstatus.DOWN,
+                description = "Det er over 24 timer siden sist vi mottok en søknad om kontantstøtte",
+            )
+            tidSidenSisteBASøknad.toHours() > 12 && tidSidenSisteKSSøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.ISSUE,
+                description = "Det er over 12 timer siden sist vi mottok en søknad om barnetrygd eller kontantstøtte",
+            )
+            tidSidenSisteBASøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.ISSUE,
+                description = "Det er over 12 timer siden sist vi mottok en søknad om barnetrygd",
+            )
+            tidSidenSisteKSSøknad.toHours() > 12 -> StatusDto(
+                status = Plattformstatus.ISSUE,
+                description = "Det er over 12 timer siden sist vi mottok en søknad om kontantstøtte",
             )
             else -> StatusDto(status = Plattformstatus.OK, description = "Alt er OK", logLink = null)
         }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/domene/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/domene/SøknadRepository.kt
@@ -10,6 +10,11 @@ import org.springframework.transaction.annotation.Transactional
 interface SøknadRepository : JpaRepository<DBSøknad, String> {
     @Query(value = "SELECT s FROM Soknad s WHERE s.id = :soknadId")
     fun hentDBSøknad(soknadId: Long): DBSøknad?
+
+    @Query(
+        "SELECT s FROM Soknad s ORDER BY s.opprettetTid DESC LIMIT 1",
+    )
+    fun finnSisteLagredeSøknad(): DBSøknad
 }
 
 @Repository

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/KontantstøtteSøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/KontantstøtteSøknadRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.baks.mottak.søknad.kontantstøtte.domene
 
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBSøknad
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -10,6 +11,11 @@ import org.springframework.transaction.annotation.Transactional
 interface KontantstøtteSøknadRepository : JpaRepository<DBKontantstøtteSøknad, String> {
     @Query(value = "SELECT s FROM kontantstotte_soknad s WHERE s.id = :soknadId")
     fun hentSøknad(soknadId: Long): DBKontantstøtteSøknad?
+
+    @Query(
+        "SELECT s FROM Soknad s ORDER BY s.opprettetTid DESC LIMIT 1",
+    )
+    fun finnSisteLagredeSøknad(): DBSøknad
 }
 
 @Repository

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/KontantstøtteSøknadRepository.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/KontantstøtteSøknadRepository.kt
@@ -13,7 +13,7 @@ interface KontantstøtteSøknadRepository : JpaRepository<DBKontantstøtteSøkna
     fun hentSøknad(soknadId: Long): DBKontantstøtteSøknad?
 
     @Query(
-        "SELECT s FROM Soknad s ORDER BY s.opprettetTid DESC LIMIT 1",
+        "SELECT s FROM kontantstotte_soknad s ORDER BY s.opprettetTid DESC LIMIT 1",
     )
     fun finnSisteLagredeSøknad(): DBSøknad
 }


### PR DESCRIPTION
Favro: [Opprette alarm dersom vi ikke mottar noen søknader på over 20 minutter (på dagtid, hverdager)](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18828)

Har kokt ganske rått av tilsvarende løsning for EF-mottak (se historikk: https://github.com/navikt/familie-ef-mottak/commits/main/src/main/kotlin/no/nav/familie/ef/mottak/api/StatusController.kt)

Splittet det på separate endepunkter per søknadstype for å holde det litt ryddig. Da kan vi liste opp og status individuelt. Bruker like knekkpunkter for tidspunkter og aktivitet enn så lenge

Har ikke testet i miljø (ennå!) - vil gjerne gå gjennom dette med en backender først 😇 

Aktivitet i BA-søknad over mandag-søndag (obs det var faktisk nedetid 13.mars) : 
<img width="1269" alt="Screenshot 2024-03-17 at 21 12 10" src="https://github.com/navikt/familie-baks-mottak/assets/2379098/21cf4532-8b33-443e-86d1-a399aecd7b88">

Aktivitet i KS-søknad over mandag-søndag:
<img width="1271" alt="Screenshot 2024-03-17 at 21 12 26" src="https://github.com/navikt/familie-baks-mottak/assets/2379098/66b9086d-7239-4e5d-b2ee-76c22721ed6f">