### PR TITLE
Legg til ingresser så vi kan nås fra statusplattform

### DIFF
--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -35,7 +35,7 @@ spec:
       memory: 1024Mi
       cpu: 200m
   ingresses:
-    - https://familie-baks-mottak.dev.intern.nav.no
+    - https://familie-baks-mottak.intern.dev.nav.no
   secureLogs:
     enabled: true
   tokenx:

--- a/.deploy/nais/app-preprod.yaml
+++ b/.deploy/nais/app-preprod.yaml
@@ -34,6 +34,8 @@ spec:
     requests:
       memory: 1024Mi
       cpu: 200m
+  ingresses:
+    - https://familie-baks-mottak.dev.intern.nav.no
   secureLogs:
     enabled: true
   tokenx:

--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -34,6 +34,8 @@ spec:
     requests:
       memory: 2Gi
       cpu: 200m
+  ingresses:
+    - https://familie-baks-mottak.intern.nav.no
   secureLogs:
     enabled: true
   tokenx:


### PR DESCRIPTION
Disse ble fjernet i #848 da vi ikke hadde kall til tjenesten utenom via service discovery, men for å støtte kall fra statusplattform (#1052) må vi ha URLer tjenesten kan nås via