### PR TITLE
Ta med søknadstype i infologg om journalføring av digital søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførKontantstøtteSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførKontantstøtteSøknadTask.kt
@@ -34,7 +34,7 @@ class JournalførKontantstøtteSøknadTask(
                     ?: error("Kunne ikke finne søknad ($id) i database")
             val versjonertSøknad = dbKontantstøtteSøknad.hentVersjonertKontantstøtteSøknad()
 
-            logger.info("Generer pdf og journalfør søknad")
+            logger.info("Generer pdf og journalfør søknad om kontantstøtte")
             val bokmålPdf =
                 pdfService.lagKontantstøttePdf(
                     versjonertSøknad = versjonertSøknad,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
@@ -31,7 +31,12 @@ class JournalførSøknadTask(
                 søknadRepository.hentDBSøknad(id.toLong()) ?: error("Kunne ikke finne søknad ($id) i database")
             val versjonertSøknad: VersjonertSøknad = dbSøknad.hentVersjonertSøknad()
 
-            log.info("Generer pdf og journalfør søknad")
+            val søknadstype =
+                when (versjonertSøknad) {
+                    is SøknadV7 -> versjonertSøknad.søknad.søknadstype
+                    is SøknadV8 -> versjonertSøknad.søknad.søknadstype
+                }
+            log.info("Generer pdf og journalfør søknad om ${søknadstype.name.lowercase()} barnetrygd")
             val bokmålPdf =
                 pdfService.lagBarnetrygdPdf(
                     versjonertSøknad = versjonertSøknad,


### PR DESCRIPTION
Bare for å gjøre logginnslaget ett hakk mer nyttig - så vi kan se i sanntid at de ulike søknadene ramler inn