### PR TITLE
Reduser cpu request

### DIFF
--- a/.deploy/nais/app-prod.yaml
+++ b/.deploy/nais/app-prod.yaml
@@ -33,7 +33,7 @@ spec:
       memory: 4Gi
     requests:
       memory: 2Gi
-      cpu: 200m
+      cpu: 50m
   secureLogs:
     enabled: true
   tokenx:


### PR DESCRIPTION
Ser vi i gjennomsnitt kun bruker 6% av CPUen vi ber om. Reduserer cpu request fra 2 x 200m til 2 x 50m. Dette vil spare oss for ~450 kroner i året


Se [nais console](https://console.nav.cloud.nais.io/team/teamfamilie/prod-gcp/app/familie-baks-mottak/utilization?from=2024-03-01&to=2024-04-11)

<img width="1255" alt="image" src="https://github.com/navikt/familie-baks-mottak/assets/17828446/784f1a8b-2420-4016-876e-143ab38dcf50">
