### PR TITLE
Legg til støtte for automatisk journalføring av søknad for barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
@@ -4,5 +4,6 @@ class FeatureToggleConfig {
     companion object {
         // Operasjonelle
         const val AUTOMATISK_JOURNALFØRING_AV_KONTANTSTØTTE_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ks-soknad"
+        const val AUTOMATISK_JOURNALFØRING_AV_BARNETRYGD_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ba-soknad"
     }
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalhendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalhendelseService.kt
@@ -10,6 +10,9 @@ import no.nav.familie.baks.mottak.integrasjoner.Journalpost
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.Journalposttype
 import no.nav.familie.baks.mottak.integrasjoner.Journalstatus
+import no.nav.familie.baks.mottak.integrasjoner.erBarnetrygdOrdinærSøknad
+import no.nav.familie.baks.mottak.integrasjoner.erBarnetrygdUtvidetSøknad
+import no.nav.familie.baks.mottak.integrasjoner.erKontantstøtteSøknad
 import no.nav.familie.baks.mottak.task.JournalhendelseBarnetrygdRutingTask
 import no.nav.familie.baks.mottak.task.JournalhendelseKontantstøtteRutingTask
 import no.nav.familie.kontrakter.felles.Tema
@@ -145,9 +148,9 @@ class JournalhendelseService(
 
     private fun behandleSkanningHendelser(journalpost: Journalpost) {
         logger.info("Ny Journalhendelse med [journalpostId=${journalpost.journalpostId}, status=${journalpost.journalstatus}, tema=${journalpost.tema}, kanal=${journalpost.kanal}]")
-        val erOrdinærBarnetrygdSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 33-00.07" } != null
-        val erUtvidetBarnetrygdSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 33-00.09" } != null
-        val erKontantstøtteSøknad = journalpost.dokumenter?.find { it.brevkode == "NAV 34-00.08" } != null
+        val erOrdinærBarnetrygdSøknad = journalpost.erBarnetrygdOrdinærSøknad()
+        val erUtvidetBarnetrygdSøknad = journalpost.erBarnetrygdUtvidetSøknad()
+        val erKontantstøtteSøknad = journalpost.erKontantstøtteSøknad()
 
         opprettJournalhendelseRutingTask(journalpost)
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.RestOperations
 import java.net.URI
+import java.time.LocalDateTime
 
 private val logger = LoggerFactory.getLogger(BaSakClient::class.java)
 
@@ -48,7 +49,7 @@ class BaSakClient
             }
         }
 
-        fun hentSaksnummer(personIdent: String): String {
+        fun hentFagsaknummerPåPersonident(personIdent: String): String {
             val uri = URI.create("$sakServiceUri/fagsaker")
             return runCatching {
                 postForEntity<Ressurs<RestFagsak>>(uri, mapOf("personIdent" to personIdent))
@@ -127,5 +128,32 @@ class BaSakClient
             } catch (e: RestClientException) {
                 throw IllegalStateException("Innsending til sak feilet.", e)
             }
+        }
+
+        fun opprettBehandling(
+            kategori: BehandlingKategori,
+            underkategori: BehandlingUnderkategori,
+            søkersIdent: String,
+            behandlingÅrsak: String,
+            søknadMottattDato: LocalDateTime,
+            behandlingType: BehandlingType,
+        ) {
+            val uri = URI.create("$sakServiceUri/behandlinger")
+            kotlin.runCatching {
+                postForEntity<Ressurs<Any>>(
+                    uri,
+                    RestOpprettBehandlingBarnetrygdRequest(
+                        kategori = kategori.name,
+                        underkategori = underkategori.name,
+                        søkersIdent = søkersIdent,
+                        behandlingÅrsak = behandlingÅrsak,
+                        søknadMottattDato = søknadMottattDato,
+                        behandlingType = behandlingType,
+                    ),
+                )
+            }
+                .onFailure {
+                    throw IntegrasjonException("Feil ved opprettelse av behandling i ks-sak.", it, uri)
+                }
         }
     }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
@@ -155,7 +155,7 @@ class BaSakClient
                 )
             }
                 .onFailure {
-                    throw IntegrasjonException("Feil ved opprettelse av behandling i ks-sak.", it, uri)
+                    throw IntegrasjonException("Feil ved opprettelse av behandling i ba-sak.", it, uri)
                 }
         }
     }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
@@ -137,6 +137,7 @@ class BaSakClient
             behandlingÅrsak: String,
             søknadMottattDato: LocalDateTime,
             behandlingType: BehandlingType,
+            fagsakId: Long,
         ) {
             val uri = URI.create("$sakServiceUri/behandlinger")
             kotlin.runCatching {
@@ -149,6 +150,7 @@ class BaSakClient
                         behandlingÅrsak = behandlingÅrsak,
                         søknadMottattDato = søknadMottattDato,
                         behandlingType = behandlingType,
+                        fagsakId = fagsakId,
                     ),
                 )
             }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -11,13 +11,15 @@ class BarnetrygdOppgaveMapper(hentEnhetClient: HentEnhetClient, pdlClient: PdlCl
     override val tema: Tema = Tema.BAR
 
     // Behandlingstema og behandlingstype settes basert på regelsettet som er dokumentert nederst her: https://confluence.adeo.no/display/TFA/Mottak+av+dokumenter
-    override fun hentBehandlingstema(journalpost: Journalpost): String? {
+    override fun hentBehandlingstema(journalpost: Journalpost): Behandlingstema? {
         return when {
-            erEØS(journalpost) -> Behandlingstema.BarnetrygdEØS.value
+            erEØS(journalpost) -> Behandlingstema.BarnetrygdEØS
             hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> null
-            else -> Behandlingstema.OrdinærBarnetrygd.value
+            else -> Behandlingstema.OrdinærBarnetrygd
         }
     }
+
+    override fun hentBehandlingstemaVerdi(journalpost: Journalpost) = hentBehandlingstema(journalpost)?.value
 
     override fun hentBehandlingstype(journalpost: Journalpost): Behandlingstype? {
         return when {
@@ -27,6 +29,18 @@ class BarnetrygdOppgaveMapper(hentEnhetClient: HentEnhetClient, pdlClient: PdlCl
     }
 
     override fun hentBehandlingstypeVerdi(journalpost: Journalpost): String? = hentBehandlingstype(journalpost)?.value
+
+    fun utledBehandlingKategori(journalpost: Journalpost) =
+        when {
+            erEØS(journalpost) -> BehandlingKategori.EØS
+            else -> BehandlingKategori.NASJONAL
+        }
+
+    fun utledBehandlingUnderkategori(journalpost: Journalpost) =
+        when {
+            journalpost.erBarnetrygdUtvidetSøknad() -> BehandlingUnderkategori.UTVIDET
+            else -> BehandlingUnderkategori.ORDINÆR
+        }
 
     private fun hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost: Journalpost) =
         // Brevkode "NAV 33-00.15" representerer dokumentet "Norsk sokkel - Årlig differanseutbetaling av barnetrygd"

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Journalpost.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Journalpost.kt
@@ -1,0 +1,85 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import java.time.LocalDateTime
+
+data class Journalpost(
+    val journalpostId: String,
+    val journalposttype: Journalposttype,
+    val journalstatus: Journalstatus,
+    val tema: String? = null,
+    val behandlingstema: String? = null,
+    val sak: Sak? = null,
+    val bruker: Bruker? = null,
+    val journalforendeEnhet: String? = null,
+    val kanal: String? = null,
+    val dokumenter: List<DokumentInfo>? = null,
+    val datoMottatt: LocalDateTime? = null,
+) {
+    fun hentHovedDokumentTittel(): String? {
+        if (dokumenter.isNullOrEmpty()) error("Journalpost $journalpostId mangler dokumenter")
+        return dokumenter.firstOrNull { it.brevkode != null }?.tittel
+    }
+}
+
+fun Journalpost.erKontantstøtteSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 34-00.08" } ?: false
+
+fun Journalpost.erBarnetrygdOrdinærSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.07" } ?: false
+
+fun Journalpost.erBarnetrygdUtvidetSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.09" } ?: false
+
+fun Journalpost.erBarnetrygdSøknad(): Boolean = erBarnetrygdOrdinærSøknad() || erBarnetrygdUtvidetSøknad()
+
+data class Sak(
+    val arkivsaksnummer: String?,
+    var arkivsaksystem: String?,
+    val fagsakId: String?,
+    val fagsaksystem: String?,
+)
+
+data class Bruker(
+    val id: String,
+    val type: BrukerIdType,
+)
+
+data class DokumentInfo(
+    val tittel: String?,
+    val brevkode: String?,
+    val dokumentstatus: Dokumentstatus?,
+    val dokumentvarianter: List<Dokumentvariant>?,
+)
+
+data class Dokumentvariant(val variantformat: String)
+
+enum class Journalposttype {
+    I,
+    U,
+    N,
+}
+
+enum class Journalstatus {
+    MOTTATT,
+    JOURNALFOERT,
+    FERDIGSTILT,
+    EKSPEDERT,
+    UNDER_ARBEID,
+    FEILREGISTRERT,
+    UTGAAR,
+    AVBRUTT,
+    UKJENT_BRUKER,
+    RESERVERT,
+    OPPLASTING_DOKUMENT,
+    UKJENT,
+}
+
+enum class Dokumentstatus {
+    FERDIGSTILT,
+    AVBRUTT,
+    UNDER_REDIGERING,
+    KASSERT,
+}
+
+enum class BrukerIdType {
+    AKTOERID,
+    FNR,
+    ORGNR,
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/JournalpostClient.kt
@@ -14,7 +14,6 @@ import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.RestOperations
 import java.net.URI
-import java.time.LocalDateTime
 
 private val logger = LoggerFactory.getLogger(JournalpostClient::class.java)
 
@@ -46,85 +45,3 @@ class JournalpostClient
             }
         }
     }
-
-data class Journalpost(
-    val journalpostId: String,
-    val journalposttype: Journalposttype,
-    val journalstatus: Journalstatus,
-    val tema: String? = null,
-    val behandlingstema: String? = null,
-    val sak: Sak? = null,
-    val bruker: Bruker? = null,
-    val journalforendeEnhet: String? = null,
-    val kanal: String? = null,
-    val dokumenter: List<DokumentInfo>? = null,
-    val datoMottatt: LocalDateTime? = null,
-) {
-    fun hentHovedDokumentTittel(): String? {
-        if (dokumenter.isNullOrEmpty()) error("Journalpost $journalpostId mangler dokumenter")
-        return dokumenter.firstOrNull { it.brevkode != null }?.tittel
-    }
-}
-
-fun Journalpost.erKontantstøtteSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 34-00.08" } ?: false
-
-fun Journalpost.erBarnetrygdOrdinærSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.07" } ?: false
-
-fun Journalpost.erBarnetrygdUtvidetSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.09" } ?: false
-
-fun Journalpost.erBarnetrygdSøknad(): Boolean = erBarnetrygdOrdinærSøknad() || erBarnetrygdUtvidetSøknad()
-
-data class Sak(
-    val arkivsaksnummer: String?,
-    var arkivsaksystem: String?,
-    val fagsakId: String?,
-    val fagsaksystem: String?,
-)
-
-data class Bruker(
-    val id: String,
-    val type: BrukerIdType,
-)
-
-data class DokumentInfo(
-    val tittel: String?,
-    val brevkode: String?,
-    val dokumentstatus: Dokumentstatus?,
-    val dokumentvarianter: List<Dokumentvariant>?,
-)
-
-data class Dokumentvariant(val variantformat: String)
-
-enum class Journalposttype {
-    I,
-    U,
-    N,
-}
-
-enum class Journalstatus {
-    MOTTATT,
-    JOURNALFOERT,
-    FERDIGSTILT,
-    EKSPEDERT,
-    UNDER_ARBEID,
-    FEILREGISTRERT,
-    UTGAAR,
-    AVBRUTT,
-    UKJENT_BRUKER,
-    RESERVERT,
-    OPPLASTING_DOKUMENT,
-    UKJENT,
-}
-
-enum class Dokumentstatus {
-    FERDIGSTILT,
-    AVBRUTT,
-    UNDER_REDIGERING,
-    KASSERT,
-}
-
-enum class BrukerIdType {
-    AKTOERID,
-    FNR,
-    ORGNR,
-}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/JournalpostClient.kt
@@ -66,6 +66,14 @@ data class Journalpost(
     }
 }
 
+fun Journalpost.erKontantstøtteSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 34-00.08" } ?: false
+
+fun Journalpost.erBarnetrygdOrdinærSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.07" } ?: false
+
+fun Journalpost.erBarnetrygdUtvidetSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.09" } ?: false
+
+fun Journalpost.erBarnetrygdSøknad(): Boolean = erBarnetrygdOrdinærSøknad() || erBarnetrygdUtvidetSøknad()
+
 data class Sak(
     val arkivsaksnummer: String?,
     var arkivsaksystem: String?,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
-import no.nav.familie.baks.mottak.util.erDnummer
+import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import org.springframework.stereotype.Service
@@ -12,19 +12,11 @@ class KontantstøtteOppgaveMapper(
 ) : AbstractOppgaveMapper(hentEnhetClient, pdlClient) {
     override val tema: Tema = Tema.KON
 
-    override fun hentBehandlingstema(journalpost: Journalpost): String? {
+    override fun hentBehandlingstema(journalpost: Journalpost): Behandlingstema? {
         return null
     }
 
-    override fun erEØS(
-        journalpost: Journalpost,
-    ): Boolean {
-        return when (journalpost.bruker?.type) {
-            BrukerIdType.FNR -> erDnummer(journalpost.bruker.id)
-            BrukerIdType.AKTOERID -> erDnummer(pdlClient.hentPersonident(journalpost.bruker.id, tema).takeIf { it.isNotEmpty() } ?: return false)
-            else -> false
-        }
-    }
+    override fun hentBehandlingstemaVerdi(journalpost: Journalpost) = hentBehandlingstema(journalpost)?.value
 
     override fun hentBehandlingstypeVerdi(journalpost: Journalpost) = hentBehandlingstype(journalpost).value
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KsSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KsSakClient.kt
@@ -54,18 +54,18 @@ class KsSakClient
             søkersIdent: String,
             behandlingÅrsak: String,
             søknadMottattDato: LocalDateTime,
-            type: BehandlingType,
+            behandlingType: BehandlingType,
         ) {
             val uri = URI.create("$ksSakServiceUri/behandlinger")
             kotlin.runCatching {
                 postForEntity<Ressurs<Any>>(
                     uri,
-                    RestOpprettBehandlingRequest(
-                        kategori,
-                        søkersIdent,
-                        behandlingÅrsak,
-                        søknadMottattDato,
-                        type,
+                    RestOpprettBehandlingKontantstøtteRequest(
+                        kategori = kategori,
+                        søkersIdent = søkersIdent,
+                        behandlingÅrsak = behandlingÅrsak,
+                        søknadMottattDato = søknadMottattDato,
+                        behandlingType = behandlingType,
                     ),
                 )
             }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClientDto.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClientDto.kt
@@ -2,7 +2,16 @@ package no.nav.familie.baks.mottak.integrasjoner
 
 import java.time.LocalDateTime
 
-data class RestOpprettBehandlingRequest(
+data class RestOpprettBehandlingKontantstøtteRequest(
+    val kategori: String,
+    val søkersIdent: String,
+    val behandlingÅrsak: String,
+    val søknadMottattDato: LocalDateTime,
+    val behandlingType: BehandlingType,
+)
+
+data class RestOpprettBehandlingBarnetrygdRequest(
+    val underkategori: String,
     val kategori: String,
     val søkersIdent: String,
     val behandlingÅrsak: String,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClientDto.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClientDto.kt
@@ -17,6 +17,7 @@ data class RestOpprettBehandlingBarnetrygdRequest(
     val behandlingÅrsak: String,
     val søknadMottattDato: LocalDateTime,
     val behandlingType: BehandlingType,
+    val fagsakId: Long,
 )
 
 data class RestPersonIdent(

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -12,6 +12,7 @@ import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.KsSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
 import no.nav.familie.baks.mottak.integrasjoner.StonadDto
+import no.nav.familie.baks.mottak.integrasjoner.erKontantstøtteSøknad
 import no.nav.familie.baks.mottak.integrasjoner.finnesÅpenBehandlingPåFagsak
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.personopplysning.FORELDERBARNRELASJONROLLE
@@ -50,7 +51,7 @@ class JournalhendelseKontantstøtteRutingTask(
 
         val harÅpenBehandlingIFagsak by lazy { ksSakClient.hentMinimalRestFagsak(fagsakId).finnesÅpenBehandlingPåFagsak() }
         val harLøpendeSakIInfotrygd = harLøpendeSakIInfotrygd(brukersIdent)
-        val erKontantstøtteSøknad = journalpost.dokumenter?.any { it.brevkode == KONTANTSTØTTE_SØKNAD_BREV_KODE } ?: false
+        val erKontantstøtteSøknad = journalpost.erKontantstøtteSøknad()
         val featureToggleForAutomatiskJournalføringSkruddPå =
             unleashService.isEnabled(
                 toggleId = FeatureToggleConfig.AUTOMATISK_JOURNALFØRING_AV_KONTANTSTØTTE_SØKNADER,
@@ -145,7 +146,6 @@ class JournalhendelseKontantstøtteRutingTask(
 
     companion object {
         const val TASK_STEP_TYPE = "journalhendelseKontantstøtteRuting"
-        const val KONTANTSTØTTE_SØKNAD_BREV_KODE = "NAV 34-00.08"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettSøknadBehandlingISakTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettSøknadBehandlingISakTask.kt
@@ -83,6 +83,7 @@ class OpprettSøknadBehandlingISakTask(
                         søkersIdent = brukersIdent,
                         søknadMottattDato = journalpost.datoMottatt ?: LocalDateTime.now(),
                         behandlingType = behandlingType,
+                        fagsakId = fagsakId.toLong(),
                     )
                 }
             }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClientTest.kt
@@ -39,7 +39,7 @@ class BaSakClientTest {
                 ),
         )
 
-        val response = baSakClient.hentSaksnummer(personIdent)
+        val response = baSakClient.hentFagsaknummerPåPersonident(personIdent)
         assertThat(response).isEqualTo(fagsakId.toString())
     }
 

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClientTest.kt
@@ -66,6 +66,14 @@ class OppgaveClientTest {
                         .withBody(objectMapper.writeValueAsString(Enhet("9999", "enhetNavn", true, "Aktiv"))),
                 ),
         )
+        stubFor(
+            post(urlEqualTo("/api/graphql"))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(readfile("mockIdentInformasjonResponse.json")),
+                ),
+        )
     }
 
     @AfterEach
@@ -117,10 +125,6 @@ class OppgaveClientTest {
     @Test
     @Tag("integration")
     fun `Opprett oppgave skal kaste feil hvis response er ugyldig`() {
-        mockResponseForPdlQuery(
-            mockResponse = readfile("mockIdentInformasjonResponse.json"),
-        )
-
         stubFor(
             post(urlEqualTo("/api/oppgave/opprett"))
                 .willReturn(
@@ -244,19 +248,6 @@ class OppgaveClientTest {
                     ),
                 ),
             )
-
-        private fun mockResponseForPdlQuery(
-            mockResponse: String,
-        ) {
-            stubFor(
-                post(urlEqualTo("/api/graphql"))
-                    .willReturn(
-                        aResponse()
-                            .withHeader("Content-Type", "application/json")
-                            .withBody(mockResponse),
-                    ),
-            )
-        }
 
         private fun readfile(filnavn: String): String {
             return this::class.java.getResource("/pdl/$filnavn").readText()

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/NavnoHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/NavnoHendelseTaskLøypeTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.Bruker
 import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
@@ -40,6 +41,7 @@ class NavnoHendelseTaskLøypeTest {
     private val mockTaskService: TaskService = mockk(relaxed = true)
     private val mockPdlClient: PdlClient = mockk(relaxed = true)
     private val mockInfotrygdBarnetrygdClient: InfotrygdBarnetrygdClient = mockk()
+    private val mockUnleashNextMedContextService: UnleashNextMedContextService = mockk()
 
     private val rutingSteg =
         JournalhendelseBarnetrygdRutingTask(
@@ -47,6 +49,8 @@ class NavnoHendelseTaskLøypeTest {
             mockSakClient,
             mockInfotrygdBarnetrygdClient,
             mockTaskService,
+            mockUnleashNextMedContextService,
+            mockJournalpostClient,
         )
 
     private val journalføringSteg =
@@ -98,6 +102,9 @@ class NavnoHendelseTaskLøypeTest {
         every {
             mockPdlClient.hentIdenter(any(), any())
         } returns listOf(IdentInformasjon("12345678910", historisk = false, gruppe = "FOLKEREGISTERIDENT"))
+        every {
+            mockUnleashNextMedContextService.isEnabled(any(), any())
+        } returns false
     }
 
     @Test
@@ -106,7 +113,7 @@ class NavnoHendelseTaskLøypeTest {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
         } returns listOf(RestFagsakDeltager("12345678901", FORELDER, FAGSAK_ID.toLong(), LØPENDE))
 
-        every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
+        every { mockSakClient.hentFagsaknummerPåPersonident(any()) } returns FAGSAK_ID
 
         kjørRutingTaskOgReturnerNesteTask().run {
             Assertions.assertThat(this.type).isEqualTo(OpprettJournalføringOppgaveTask.TASK_STEP_TYPE)
@@ -146,7 +153,7 @@ class NavnoHendelseTaskLøypeTest {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
         } returns listOf(RestFagsakDeltager("12345678901", FORELDER, FAGSAK_ID.toLong(), LØPENDE))
 
-        every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
+        every { mockSakClient.hentFagsaknummerPåPersonident(any()) } returns FAGSAK_ID
 
         every {
             mockInfotrygdBarnetrygdClient.hentLøpendeUtbetalinger(any(), any())
@@ -179,7 +186,7 @@ class NavnoHendelseTaskLøypeTest {
             mockSakClient.hentRestFagsakDeltagerListe(any(), emptyList())
         } returns listOf(RestFagsakDeltager("12345678901", FORELDER, FAGSAK_ID.toLong(), LØPENDE))
 
-        every { mockSakClient.hentSaksnummer(any()) } returns FAGSAK_ID
+        every { mockSakClient.hentFagsaknummerPåPersonident(any()) } returns FAGSAK_ID
 
         every {
             mockInfotrygdBarnetrygdClient.hentSaker(any(), any())

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/SkanHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/SkanHendelseTaskLøypeTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.hendelser.JournalføringHendelseServiceTest
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.Bruker
@@ -40,6 +41,7 @@ class SkanHendelseTaskLøypeTest {
     private val mockTaskService: TaskService = mockk(relaxed = true)
     private val mockPdlClient: PdlClient = mockk(relaxed = true)
     private val mockInfotrygdBarnetrygdClient: InfotrygdBarnetrygdClient = mockk()
+    private val mockUnleashNextMedContextService: UnleashNextMedContextService = mockk()
 
     private val rutingSteg =
         JournalhendelseBarnetrygdRutingTask(
@@ -47,6 +49,8 @@ class SkanHendelseTaskLøypeTest {
             mockSakClient,
             mockInfotrygdBarnetrygdClient,
             mockTaskService,
+            mockUnleashNextMedContextService,
+            mockJournalpostClient,
         )
 
     private val journalføringSteg =
@@ -102,6 +106,10 @@ class SkanHendelseTaskLøypeTest {
         every {
             mockInfotrygdBarnetrygdClient.hentSaker(any(), any())
         } returns InfotrygdSøkResponse(emptyList(), emptyList())
+
+        every {
+            mockUnleashNextMedContextService.isEnabled(any(), any())
+        } returns false
     }
 
     @Test


### PR DESCRIPTION
Bygger videre på denne: https://github.com/navikt/familie-baks-mottak/pull/1082

Hva er gjort og hva er testet?
Når vi mottar digitale barnetrygd søknader i dag så opprettes det en journalføringsoppgave på disse.
Vi ønsker heller nå å kunne automatisk journalføre og ferdigstille disse. Flyten er nå derfor blitt slik:

Når vi mottar en journalpost:
- Sjekk om det er en digital søknad m/ brevkode NAV 34-00.07 eller NAV 34-00.09 (hvis ja, gå videre. hvis ikke bruk dagens prosess)
- Sjekk om bruker har en pågående sak i infotrygd eller åpen behandling i ba-sak (hvis nei, gå videre. hvis ja bruk dagens prosess)

Dersom vi går videre med prosessen så vil dette nå skje:
- Vi oppretter fagsak på person (hopper over dette hvis person allerede har fagsak)
- Vi oppdaterer journalposten, kobler den til fagsaken, og ferdigstiller den
- Vi oppretter behandling med årsak søknad. Typen er førstegangsbehandling eller revurdering avhengig av hva bruker har av behandlinger i fagsaken. Vi setter også kategori til NASJONAL eller EØS basert på fødselsnummeret til bruker. Dette er eksisterende logikk som vi skal forbedre i neste omgang. Underkategori blir satt basert på om det er ordinær eller utvidet (00.07 eller 00.09)
- Det opprettes en behandle sak oppgave når behandlingen er opprettet med frist samme dag. Dette skjer i de familie-ba-sak.

Dersom vi ikke går videre med prosessen eller noe feiler så vil vi opprette en journalføringsoppgave som i dag.
Dersom vi har kommet så langt at journalposten har blitt ferdigstilt, men opprettelsen av behandling feiler, så opprettes det ikke en journalføringsoppgave. I disse tilfelle tenker jeg at vi bør se på hvorfor opprettelsen av behandlingen feiler.

Følgende scenarioer er testet av meg.
- Barnetrygd Ordinær søknad av noen som ikke har fagsak (opprettes fagsak, førstegangsbehandling nasjonal ordinær)
- Barnetrygd Ordinær søknad av noen som har fagsak (førstegangsbehandling nasjonal ordinær)
- Barnetrygd Utvidet søknad av noen som ikke har fagsak (opprettes fagsak, førstegangsbehandling nasjonal utvidet)
- Barnetrygd Utvidet søknad av noen som har fagsak (førstegangsbehandling nasjonal utvidet)
- Barnetrygd Ordinær søknad søknad av noen som løpende fagsak (opprettes revurdering behandling nasjonal ordinær
- Barnetrygd søknad av noen som har DNR og ikke fagsak (opprettes eøs førstegangsbehandling ordinær)
