### PR TITLE
Lagt til avro-schema for Foedselsdato

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
@@ -57,6 +57,7 @@ class LeesahService(
             OPPLYSNINGSTYPE_FØDSEL -> behandleFødselsHendelse(pdlHendelse)
             OPPLYSNINGSTYPE_UTFLYTTING -> behandleUtflyttingHendelse(pdlHendelse)
             OPPLYSNINGSTYPE_SIVILSTAND -> behandleSivilstandHendelse(pdlHendelse)
+            OPPLYSNINGSTYPE_FØDSELSDATO -> behandleFødselsdatoHendelse(pdlHendelse)
         }
     }
 
@@ -160,6 +161,14 @@ class LeesahService(
             else -> {
                 logHendelse(pdlHendelse)
             }
+        }
+        oppdaterHendelseslogg(pdlHendelse)
+    }
+
+    private fun behandleFødselsdatoHendelse(pdlHendelse: PdlHendelse) {
+        if (hendelsesloggRepository.existsByHendelseIdAndConsumer(pdlHendelse.hendelseId, CONSUMER_PDL)) {
+            leesahDuplikatCounter.increment()
+            return
         }
         oppdaterHendelseslogg(pdlHendelse)
     }
@@ -318,6 +327,7 @@ class LeesahService(
         const val ANNULLERT = "ANNULLERT"
         const val OPPLYSNINGSTYPE_DØDSFALL = "DOEDSFALL_V1"
         const val OPPLYSNINGSTYPE_FØDSEL = "FOEDSEL_V1"
+        const val OPPLYSNINGSTYPE_FØDSELSDATO = "FOEDSELSDATO_V1"
         const val OPPLYSNINGSTYPE_UTFLYTTING = "UTFLYTTING_FRA_NORGE"
         const val OPPLYSNINGSTYPE_SIVILSTAND = "SIVILSTAND_V1"
     }

--- a/src/main/resources/avro/leesah/Personhendelse.avdl
+++ b/src/main/resources/avro/leesah/Personhendelse.avdl
@@ -4,6 +4,7 @@ protocol PersonhendelseProto {
   import idl "doedfoedtbarn/DoedfoedtBarn.avdl";
   import idl "doedsfall/Doedsfall.avdl";
   import idl "foedsel/Foedsel.avdl";
+  import idl "foedselsdato/Foedselsdato.avdl";
   import idl "familierelasjon/Familierelasjon.avdl";
   import idl "verge/VergemaalEllerFremtidsfullmakt.avdl";
   import idl "forelderbarnrelasjon/ForelderBarnRelasjon.avdl";
@@ -40,6 +41,7 @@ protocol PersonhendelseProto {
     union { null, no.nav.person.pdl.leesah.doedfoedtbarn.DoedfoedtBarn } doedfoedtBarn = null;
     union { null, no.nav.person.pdl.leesah.doedsfall.Doedsfall } doedsfall = null;
     union { null, no.nav.person.pdl.leesah.foedsel.Foedsel } foedsel = null;
+    union { null, no.nav.person.pdl.leesah.foedselsdato.Foedselsdato } foedselsdato = null;
     union { null, no.nav.person.pdl.leesah.forelderbarnrelasjon.ForelderBarnRelasjon } forelderBarnRelasjon = null;
     union { null, no.nav.person.pdl.leesah.familierelasjon.Familierelasjon } familierelasjon = null; // Blir DEPRECATED i fremtiden. Erstattes av forelderBarnRelasjon.
     union { null, no.nav.person.pdl.leesah.sivilstand.Sivilstand } sivilstand = null;

--- a/src/main/resources/avro/leesah/foedselsdato/Foedselsdato.avdl
+++ b/src/main/resources/avro/leesah/foedselsdato/Foedselsdato.avdl
@@ -1,0 +1,8 @@
+@namespace("no.nav.person.pdl.leesah.foedselsdato")
+protocol FoedselsdatoV1 {
+
+  record Foedselsdato {
+    union { null, int } foedselsaar = null;
+    union { null, date } foedselsdato = null;
+  }
+}


### PR DESCRIPTION
Steg en fra å gå fra Foedsel til Foedselsdato.

Denne gjør det slik at vi leser Foedselsdato og lagrer ned at vi har lest den i hendelsetabellen. Dette for å unngå at man sender duplikate hendelser hvis man evt skulle miste offset.

Neste steg blir å bytte fødselshendelse fra FOEDSEL_V1 til FOEDSELSDATO_V1