### PR TITLE
Fødeland utenfor norge ikke ignorert

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/MottaFødselshendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/MottaFødselshendelseTask.kt
@@ -53,6 +53,7 @@ class MottaFødselshendelseTask(
         if (pdlPersonData.fødested.first().erUtenforNorge()) {
             log.info("Fødeland er ikke Norge. Ignorerer hendelse")
             fødselIgnorertFødelandCounter.increment()
+            return
         }
 
         try {


### PR DESCRIPTION
I forbindelse med at man byttet fra foedsel til foedselsdato, så ble koden for å ignorere hendelse på fødeland flyttet til task. Det logges at man ignorerer hendelsen, men man ignorerer faktisk ikke.
