### PR TITLE
Fikser automatisk journalføring hvor sak eksisterer alt for barnetrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaSakClient.kt
@@ -52,7 +52,7 @@ class BaSakClient
         fun hentFagsaknummerPåPersonident(personIdent: String): String {
             val uri = URI.create("$sakServiceUri/fagsaker")
             return runCatching {
-                postForEntity<Ressurs<RestFagsak>>(uri, mapOf("personIdent" to personIdent))
+                postForEntity<Ressurs<RestFagsakId>>(uri, mapOf("personIdent" to personIdent))
             }.fold(
                 onSuccess = { it.data?.id?.toString() ?: throw IntegrasjonException(it.melding, null, uri, personIdent) },
                 onFailure = { throw IntegrasjonException("Feil ved henting av saksnummer fra ba-sak.", it, uri, personIdent) },

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Journalpost.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Journalpost.kt
@@ -29,6 +29,8 @@ fun Journalpost.erBarnetrygdUtvidetSøknad(): Boolean = dokumenter?.any { it.bre
 
 fun Journalpost.erBarnetrygdSøknad(): Boolean = erBarnetrygdOrdinærSøknad() || erBarnetrygdUtvidetSøknad()
 
+fun Journalpost.erDigitalKanal(): Boolean = kanal == "NAV_NO"
+
 data class Sak(
     val arkivsaksnummer: String?,
     var arkivsaksystem: String?,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClient.kt
@@ -40,7 +40,7 @@ class OppgaveClient
             journalpost: Journalpost,
             beskrivelse: String? = null,
         ): OppgaveResponse {
-            logger.info("Oppretter journalføringsoppgave for ${if (journalpost.kanal == "NAV_NO") "digital søknad" else "papirsøknad"}")
+            logger.info("Oppretter journalføringsoppgave for ${if (journalpost.erDigitalKanal()) "digital søknad" else "papirsøknad"}")
             val uri = URI.create("$integrasjonUri/oppgave/opprett")
             val request =
                 oppgaveMapperService.tilOpprettOppgaveRequest(

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClientDto.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SakClientDto.kt
@@ -53,6 +53,10 @@ data class RestFagsak(
     val behandlinger: List<RestUtvidetBehandling>,
 )
 
+data class RestFagsakId(
+    val id: Long,
+)
+
 data class RestUtvidetBehandling(
     val aktiv: Boolean,
     val arbeidsfordelingPåBehandling: RestArbeidsfordelingPåBehandling?,
@@ -60,7 +64,7 @@ data class RestUtvidetBehandling(
     val kategori: BehandlingKategori,
     val opprettetTidspunkt: LocalDateTime,
     val resultat: String,
-    val steg: String,
+    val steg: String?,
     val type: String,
     val underkategori: BehandlingUnderkategori,
 )

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseBarnetrygdRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseBarnetrygdRutingTask.kt
@@ -82,8 +82,9 @@ class JournalhendelseBarnetrygdRutingTask(
             featureToggleForAutomatiskJournalføringSkruddPå &&
                 erBarnetrygdSøknad &&
                 !brukerHarSakIInfotrygd &&
-                !harÅpenBehandlingIFagsak &&
-                journalførendeEnhet !in enheterSomIkkeSkalHaAutomatiskJournalføring
+                journalførendeEnhet !in enheterSomIkkeSkalHaAutomatiskJournalføring &&
+                journalpost.kanal == "NAV_NO" &&
+                !harÅpenBehandlingIFagsak
 
         if (skalAutomatiskJournalføreJournalpost) {
             log.info("Oppretter OppdaterOgFerdigstillJournalpostTask for journalpost med id ${journalpost.journalpostId}")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseBarnetrygdRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseBarnetrygdRutingTask.kt
@@ -22,6 +22,7 @@ import no.nav.familie.baks.mottak.integrasjoner.RestFagsak
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsakDeltager
 import no.nav.familie.baks.mottak.integrasjoner.StatusKode
 import no.nav.familie.baks.mottak.integrasjoner.erBarnetrygdSøknad
+import no.nav.familie.baks.mottak.integrasjoner.erDigitalKanal
 import no.nav.familie.baks.mottak.integrasjoner.finnesÅpenBehandlingPåFagsak
 import no.nav.familie.kontrakter.ba.infotrygd.InfotrygdSøkResponse
 import no.nav.familie.kontrakter.felles.Tema
@@ -83,7 +84,7 @@ class JournalhendelseBarnetrygdRutingTask(
                 erBarnetrygdSøknad &&
                 !brukerHarSakIInfotrygd &&
                 journalførendeEnhet !in enheterSomIkkeSkalHaAutomatiskJournalføring &&
-                journalpost.kanal == "NAV_NO" &&
+                journalpost.erDigitalKanal() &&
                 !harÅpenBehandlingIFagsak
 
         if (skalAutomatiskJournalføreJournalpost) {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -12,6 +12,7 @@ import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient
 import no.nav.familie.baks.mottak.integrasjoner.KsSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
 import no.nav.familie.baks.mottak.integrasjoner.StonadDto
+import no.nav.familie.baks.mottak.integrasjoner.erDigitalKanal
 import no.nav.familie.baks.mottak.integrasjoner.erKontantstøtteSøknad
 import no.nav.familie.baks.mottak.integrasjoner.finnesÅpenBehandlingPåFagsak
 import no.nav.familie.kontrakter.felles.Tema
@@ -65,7 +66,7 @@ class JournalhendelseKontantstøtteRutingTask(
             featureToggleForAutomatiskJournalføringSkruddPå &&
                 erKontantstøtteSøknad &&
                 !harLøpendeSakIInfotrygd &&
-                journalpost.kanal == "NAV_NO" &&
+                journalpost.erDigitalKanal() &&
                 journalførendeEnhet !in enheterSomIkkeSkalHaAutomatiskJournalføring &&
                 !harÅpenBehandlingIFagsak
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTask.kt
@@ -65,8 +65,9 @@ class JournalhendelseKontantstøtteRutingTask(
             featureToggleForAutomatiskJournalføringSkruddPå &&
                 erKontantstøtteSøknad &&
                 !harLøpendeSakIInfotrygd &&
-                !harÅpenBehandlingIFagsak &&
-                journalførendeEnhet !in enheterSomIkkeSkalHaAutomatiskJournalføring
+                journalpost.kanal == "NAV_NO" &&
+                journalførendeEnhet !in enheterSomIkkeSkalHaAutomatiskJournalføring &&
+                !harÅpenBehandlingIFagsak
 
         if (skalAutomatiskJournalføreJournalpost) {
             log.info("Oppretter OppdaterOgFerdigstillJournalpostTask for journalpost med id ${journalpost.journalpostId}")


### PR DESCRIPTION
hent fagsakid trenger kun å mappe opp fagsakId. Hvis man mapper til hele restfagsaken med behandlinger, så er det større sjanse for mappingsfeil