### PR TITLE
Sett riktig behandlingstema på BA søknader

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -19,8 +19,8 @@ class BarnetrygdOppgaveMapper(
     override fun hentBehandlingstema(journalpost: Journalpost): Behandlingstema? =
         when {
             journalpost.erBarnetrygdSøknad() && journalpost.erDigitalKanal() ->
-                if (utledBehandlingKategoriFraSøknad(journalpost) == BehandlingKategori.EØS) {
-                    Behandlingstema.BarnetrygdEØS
+                if (utledBehandlingUnderkategoriFraSøknad(journalpost) == BehandlingUnderkategori.UTVIDET) {
+                    Behandlingstema.UtvidetBarnetrygd
                 } else {
                     Behandlingstema.OrdinærBarnetrygd
                 }


### PR DESCRIPTION
Dersom det er digital BA søknad ønsker vi ikke å sette BarnetrygdEØS som behandlingstema.
Da ønsker vi å sette enten ordinær eller utvidet.