### PR TITLE
Fix: StatusController returnerer alltid OK

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/StatusController.kt
@@ -23,8 +23,9 @@ class StatusController(
     @GetMapping(value = ["/barnetrygd"])
     @Unprotected
     fun statusBarnetrygd(): StatusDto {
+        logger.info("Sjekker status på barnetrygd søknad.")
         val sistBarnetrygdSøknad = barnetrygdSøknadRepository.finnSisteLagredeSøknad()
-        val tidSidenSisteBarnetrygdSøknad = Duration.between(LocalDateTime.now(), sistBarnetrygdSøknad.opprettetTid)
+        val tidSidenSisteBarnetrygdSøknad = Duration.between(sistBarnetrygdSøknad.opprettetTid, LocalDateTime.now())
         loggHvisLiteAktivitet(tidSidenSisteBarnetrygdSøknad, Søknadstype.BARNETRYGD)
         return lagStatusDto(tidSidenSisteBarnetrygdSøknad, Søknadstype.BARNETRYGD)
     }
@@ -34,7 +35,7 @@ class StatusController(
     fun statusKontantstøtte(): StatusDto {
         logger.info("Sjekker status på kontantstøtte søknad.")
         val sistKontantstøtteSøknad = kontantstøtteSøknadRepository.finnSisteLagredeSøknad()
-        val tidSidenSisteKontantstøtteSøknad = Duration.between(LocalDateTime.now(), sistKontantstøtteSøknad.opprettetTid)
+        val tidSidenSisteKontantstøtteSøknad = Duration.between(sistKontantstøtteSøknad.opprettetTid, LocalDateTime.now())
         loggHvisLiteAktivitet(tidSidenSisteKontantstøtteSøknad, Søknadstype.KONTANTSTØTTE)
         return lagStatusDto(tidSidenSisteKontantstøtteSøknad, Søknadstype.KONTANTSTØTTE)
     }
@@ -45,8 +46,9 @@ class StatusController(
     ) {
         if (erDagtid() && !erHelg()) {
             when {
-                tidSidenSisteSøknad.toHours() > 3 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteSøknad.toHours()} timer siden vi sist mottok en søknad om ${søknadstype.name.lowercase()}")
-                tidSidenSisteSøknad.toMinutes() > 20 -> logger.warn("Status baks-mottak: Det er ${tidSidenSisteSøknad.toMinutes()} minutter siden vi sist mottok en søknad om ${søknadstype.name.lowercase()}")
+                tidSidenSisteSøknad.toHours() >= 3 -> logger.error("Status baks-mottak: Det er ${tidSidenSisteSøknad.toHours()} timer siden vi sist mottok en søknad om ${søknadstype.name.lowercase()}")
+                tidSidenSisteSøknad.toMinutes() >= 20 -> logger.warn("Status baks-mottak: Det er ${tidSidenSisteSøknad.toMinutes()} minutter siden vi sist mottok en søknad om ${søknadstype.name.lowercase()}")
+                else -> logger.info("Status baks-mottak: Det er ${tidSidenSisteSøknad.toMinutes()} minutter siden vi sist mottok en søknad om ${søknadstype.name.lowercase()}")
             }
         }
     }
@@ -65,7 +67,7 @@ class StatusController(
         søknadstype: Søknadstype,
     ) =
         when {
-            tidSidenSisteSøknad.toHours() > 12 ->
+            tidSidenSisteSøknad.toHours() >= 12 ->
                 StatusDto(
                     status = Plattformstatus.DOWN,
                     description = "Det er over 12 timer siden sist vi mottok en søknad om ${søknadstype.name.lowercase()}",
@@ -79,13 +81,13 @@ class StatusController(
         søknadstype: Søknadstype,
     ) =
         when {
-            tidSidenSisteSøknad.toHours() > 24 ->
+            tidSidenSisteSøknad.toHours() >= 24 ->
                 StatusDto(
                     status = Plattformstatus.DOWN,
                     description = "Det er over 24 timer siden sist vi mottok en søknad om ${søknadstype.name.lowercase()}",
                 )
 
-            tidSidenSisteSøknad.toHours() > 12 ->
+            tidSidenSisteSøknad.toHours() >= 12 ->
                 StatusDto(
                     status = Plattformstatus.ISSUE,
                     description = "Det er over 12 timer siden sist vi mottok en søknad om ${søknadstype.name.lowercase()}",
@@ -98,7 +100,7 @@ class StatusController(
 
     private fun erDagtid() = LocalDateTime.now().hour in 9..22
 
-    private fun erTidspunktMedForventetAktivitet() = LocalDateTime.now().hour in 12..21
+    private fun erTidspunktMedForventetAktivitet() = LocalDateTime.now().hour in 9..22
 }
 
 const val LOG_URL = "https://logs.adeo.no/app/r/s/OJZqp"

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/StatusControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/StatusControllerTest.kt
@@ -1,0 +1,156 @@
+package no.nav.familie.baks.mottak.søknad
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+class StatusControllerTest {
+    private val søknadRepository = mockk<SøknadRepository>()
+    private val kontantstøtteSøknadRepository = mockk<KontantstøtteSøknadRepository>()
+    private val statusController = StatusController(søknadRepository, kontantstøtteSøknadRepository)
+    private val logAppender = LogAppender()
+    private val logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as ch.qos.logback.classic.Logger
+
+    @BeforeEach
+    fun beforeEach() {
+        mockkStatic(LocalDateTime::class)
+        logger.addAppender(logAppender)
+        logAppender.start()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        unmockkStatic(LocalDateTime::class)
+    }
+
+    @Test
+    fun `skal gi status DOWN dersom det ikke har kommet inn noen søknader på 12 timer`() {
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 8, 2, 10, 0)
+        every { kontantstøtteSøknadRepository.finnSisteLagredeSøknad() } returns
+            DBKontantstøtteSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 1, 21, 59),
+                fnr = "",
+            )
+        every { søknadRepository.finnSisteLagredeSøknad() } returns
+            DBBarnetrygdSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 1, 21, 59),
+                fnr = "",
+            )
+        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusBarnetrygd = statusController.statusBarnetrygd()
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `skal gi status DOWN dersom det er natt og det ikke har kommet inn noen søknader på 24 timer`() {
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 8, 2, 2, 0)
+        every { kontantstøtteSøknadRepository.finnSisteLagredeSøknad() } returns
+            DBKontantstøtteSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 1, 1, 59),
+                fnr = "",
+            )
+        every { søknadRepository.finnSisteLagredeSøknad() } returns
+            DBBarnetrygdSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 1, 1, 59),
+                fnr = "",
+            )
+        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusBarnetrygd = statusController.statusBarnetrygd()
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
+    }
+
+    @Test
+    fun `skal gi status ISSUE dersom det er natt og det ikke har kommet inn noen søknader på 12 timer`() {
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 8, 2, 2, 0)
+        every { kontantstøtteSøknadRepository.finnSisteLagredeSøknad() } returns
+            DBKontantstøtteSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 1, 13, 59),
+                fnr = "",
+            )
+        every { søknadRepository.finnSisteLagredeSøknad() } returns
+            DBBarnetrygdSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 1, 13, 59),
+                fnr = "",
+            )
+        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusBarnetrygd = statusController.statusBarnetrygd()
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.ISSUE)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.ISSUE)
+    }
+
+    @Test
+    fun `skal logge error dersom det er dagtid og ikke helg og mer enn 3 timer siden vi har mottatt en søknad`() {
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 8, 2, 10, 0)
+        every { kontantstøtteSøknadRepository.finnSisteLagredeSøknad() } returns
+            DBKontantstøtteSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 2, 6, 59),
+                fnr = "",
+            )
+        every { søknadRepository.finnSisteLagredeSøknad() } returns
+            DBBarnetrygdSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 2, 6, 59),
+                fnr = "",
+            )
+        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusBarnetrygd = statusController.statusBarnetrygd()
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
+        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `skal logge warning dersom det er dagtid og ikke helg og mer enn 20 minutter siden vi har mottatt en søknad`() {
+        every { LocalDateTime.now() } returns LocalDateTime.of(2024, 8, 2, 10, 0)
+        every { kontantstøtteSøknadRepository.finnSisteLagredeSøknad() } returns
+            DBKontantstøtteSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 2, 9, 40),
+                fnr = "",
+            )
+        every { søknadRepository.finnSisteLagredeSøknad() } returns
+            DBBarnetrygdSøknad(
+                søknadJson = "",
+                opprettetTid = LocalDateTime.of(2024, 8, 2, 9, 40),
+                fnr = "",
+            )
+        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusBarnetrygd = statusController.statusBarnetrygd()
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
+        assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(2)
+    }
+
+    class LogAppender : AppenderBase<ILoggingEvent>() {
+        val logEvents: MutableList<ILoggingEvent> = mutableListOf()
+
+        override fun append(eventObject: ILoggingEvent) {
+            logEvents.add(eventObject)
+        }
+    }
+}


### PR DESCRIPTION
Favro: [NAV-21901](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21901)

Ved nedetid for kontantstøttesøknaden 02.08.24, hvor vi ikke mottok noen nye søknader i tidsrommet 15:41 -> 12:21, returnerte StatusController-endepunktet `api/status/kontantstotte` fortsatt OK og ingen feil ble logget.

* Sørger for at vi utleder `tidSidenSisteSøknad` riktig. Tidligere ble ingenting logget fordi `tidSidenSisteSøknad` alltid ga negative tall for `Duration.toHours()` og `Duration.toMinutes()`. 
* Har utvidet tidsintervallet for når vi forventer aktivitet fra [12:00 -> 21:00] til [09:00 -> 22:00].
* Lagt til litt ekstra logging for bedre innsikt.
* Laget tester for de ulike scenariene.