### PR TITLE
Så lenge en sak ikke er løpende skal vi opprette en førstegangsbehandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettSøknadBehandlingISakTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettSøknadBehandlingISakTask.kt
@@ -93,14 +93,10 @@ class OpprettSøknadBehandlingISakTask(
     }
 
     private fun utledBehandlingstype(fagsak: RestMinimalFagsak): BehandlingType {
-        val erFagsakLøpendeOgAktiveBehandlingerAvsluttet =
-            fagsak.behandlinger.any { behandling ->
-                val kanOppretteBehandling = behandling.status == BehandlingStatus.AVSLUTTET && behandling.aktiv
-                fagsak.status != FagsakStatus.LØPENDE && kanOppretteBehandling
-            }
+        val erFagsakLøpende = fagsak.status == FagsakStatus.LØPENDE
 
         val type =
-            if (erFagsakLøpendeOgAktiveBehandlingerAvsluttet || fagsak.behandlinger.isEmpty()) {
+            if (!erFagsakLøpende) {
                 BehandlingType.FØRSTEGANGSBEHANDLING
             } else {
                 BehandlingType.REVURDERING

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettSøknadBehandlingISakTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/OpprettSøknadBehandlingISakTask.kt
@@ -2,7 +2,6 @@ package no.nav.familie.baks.mottak.task
 
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.BarnetrygdOppgaveMapper
-import no.nav.familie.baks.mottak.integrasjoner.BehandlingStatus
 import no.nav.familie.baks.mottak.integrasjoner.BehandlingType
 import no.nav.familie.baks.mottak.integrasjoner.FagsakStatus
 import no.nav.familie.baks.mottak.integrasjoner.JournalpostClient


### PR DESCRIPTION
utledBehandlingstype feilet når det bare eksisterte henlagte behandlinger. Dette fordi en henlagt behandling blir satt til ikke aktiv med engang.

Jeg tok en prat med Anna, og vi går for denne enkle regelen:
Så lenge fagsak ikke er løpende, oppretter vi førstegangsbehandling.