### PR TITLE
Sørger for at vi gjør status-sjekk uavhengig av Statusplattform

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/SøknadStatusController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/SøknadStatusController.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.baks.mottak.søknad
+
+import no.nav.security.token.support.core.api.Unprotected
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/api/status"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class SøknadStatusController(
+    val søknadStatusService: SøknadStatusService,
+) {
+    @GetMapping(value = ["/barnetrygd"])
+    @Unprotected
+    fun statusBarnetrygd(): StatusDto = søknadStatusService.statusBarnetrygd()
+
+    @GetMapping(value = ["/kontantstotte"])
+    @Unprotected
+    fun statusKontantstøtte(): StatusDto = søknadStatusService.statusKontantstøtte()
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadStatusServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,10 +19,10 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 
-class StatusControllerTest {
+class SøknadStatusServiceTest {
     private val søknadRepository = mockk<SøknadRepository>()
     private val kontantstøtteSøknadRepository = mockk<KontantstøtteSøknadRepository>()
-    private val statusController = StatusController(søknadRepository, kontantstøtteSøknadRepository)
+    private val søknadStatusService = SøknadStatusService(søknadRepository, kontantstøtteSøknadRepository)
     private val logAppender = LogAppender()
     private val logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as ch.qos.logback.classic.Logger
 
@@ -50,11 +50,11 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
-        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
+        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -69,11 +69,11 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusBarnetrygd = statusController.statusBarnetrygd()
+        val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
-        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
+        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -88,10 +88,10 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
+        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
     }
 
     @Test
@@ -106,10 +106,10 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusBarnetrygd = statusController.statusBarnetrygd()
+        val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
+        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
     }
 
     @Test
@@ -124,10 +124,10 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.ISSUE)
+        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.ISSUE)
     }
 
     @Test
@@ -142,10 +142,10 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusBarnetrygd = statusController.statusBarnetrygd()
+        val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.ISSUE)
+        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.ISSUE)
     }
 
     @Test
@@ -160,11 +160,11 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
-        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
+        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -179,11 +179,11 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusBarnetrygd = statusController.statusBarnetrygd()
+        val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
-        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
+        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -198,11 +198,11 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusKontantstøtte = statusController.statusKontantstøtte()
+        val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
-        assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
+        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
+        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
     }
 
     @Test
@@ -217,11 +217,11 @@ class StatusControllerTest {
             )
 
         // Act
-        val statusBarnetrygd = statusController.statusBarnetrygd()
+        val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
-        assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
+        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
+        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
     }
 
     class LogAppender : AppenderBase<ILoggingEvent>() {

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadStatusServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -53,8 +53,8 @@ class SøknadStatusServiceTest {
         val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
-        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -72,8 +72,8 @@ class SøknadStatusServiceTest {
         val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
-        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -91,7 +91,7 @@ class SøknadStatusServiceTest {
         val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.DOWN)
     }
 
     @Test
@@ -109,7 +109,7 @@ class SøknadStatusServiceTest {
         val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.DOWN)
     }
 
     @Test
@@ -127,7 +127,7 @@ class SøknadStatusServiceTest {
         val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.ISSUE)
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.ISSUE)
     }
 
     @Test
@@ -145,7 +145,7 @@ class SøknadStatusServiceTest {
         val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.ISSUE)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.ISSUE)
     }
 
     @Test
@@ -163,8 +163,8 @@ class SøknadStatusServiceTest {
         val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
-        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
+        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -182,8 +182,8 @@ class SøknadStatusServiceTest {
         val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
-        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
+        assertThat(logAppender.logEvents.filter { it.level == Level.ERROR }.size).isEqualTo(1)
     }
 
     @Test
@@ -201,8 +201,8 @@ class SøknadStatusServiceTest {
         val statusKontantstøtte = søknadStatusService.statusKontantstøtte()
 
         // Assert
-        Assertions.assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
-        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
+        assertThat(statusKontantstøtte.status).isEqualTo(Plattformstatus.OK)
+        assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
     }
 
     @Test
@@ -220,8 +220,8 @@ class SøknadStatusServiceTest {
         val statusBarnetrygd = søknadStatusService.statusBarnetrygd()
 
         // Assert
-        Assertions.assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
-        Assertions.assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
+        assertThat(statusBarnetrygd.status).isEqualTo(Plattformstatus.OK)
+        assertThat(logAppender.logEvents.filter { it.level == Level.WARN }.size).isEqualTo(1)
     }
 
     class LogAppender : AppenderBase<ILoggingEvent>() {


### PR DESCRIPTION
Har flyttet all status-sjekk kode ut fra Controller og inn i egen Service, og lagt til en @Scheduled-funksjon som trigger status-sjekk for Barnetrygd og Kontantstøtte hvert 30 minutt. 