### PR TITLE
Ved sjekk av enhet så ønsker vi å sjekke enhet på person, ikke enhet på journalføringen da den er satt til 9999 (automatisk)

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/ArbeidsfordelingClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/ArbeidsfordelingClient.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+@Component
+class ArbeidsfordelingClient(
+    @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
+    @Qualifier("clientCredentials") restOperations: RestOperations,
+) : AbstractRestClient(restOperations, "integrasjon") {
+    fun hentBehandlendeEnhetPåIdent(
+        personIdent: String,
+        tema: Tema,
+    ): Enhet {
+        val uri = URI.create("$integrasjonUri/arbeidsfordeling/enhet/$tema")
+        return runCatching {
+            postForEntity<Ressurs<Enhet>>(uri, RestPersonIdent(personIdent))
+        }.fold(
+            onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri, ident = personIdent) },
+            onFailure = { throw IntegrasjonException("Feil ved henting av behandlende enhet på ident m/ tema $tema", it, uri, personIdent) },
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/ArbeidsfordelingClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/ArbeidsfordelingClientTest.kt
@@ -1,0 +1,58 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import no.nav.familie.baks.mottak.DevLauncher
+import no.nav.familie.kontrakter.felles.Tema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(classes = [DevLauncher::class], properties = ["FAMILIE_INTEGRASJONER_API_URL=http://localhost:28085/api"])
+@ActiveProfiles("dev", "mock-oauth")
+@AutoConfigureWireMock(port = 28085)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ArbeidsfordelingClientTest {
+    @Autowired
+    lateinit var arbeidsfordelingClient: ArbeidsfordelingClient
+
+    @Test
+    @Tag("integration")
+    fun `hentBehandlendeEnhetPåIdent skal returnere enhet på person`() {
+        stubFor(
+            WireMock.post(urlEqualTo("/api/arbeidsfordeling/enhet/KON")).withRequestBody(WireMock.equalToJson("""{"personIdent":"123"}""")).willReturn(
+                aResponse().withHeader("Content-Type", "application/json").withBody(
+                    gyldigEnhetResponse(),
+                ),
+            ),
+        )
+
+        val response =
+            arbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
+                personIdent = "123",
+                tema = Tema.KON,
+            )
+        assertThat(response.enhetId).isEqualTo("4863")
+        assertThat(response.enhetNavn).isEqualTo("Enhet 4863")
+    }
+
+    private fun gyldigEnhetResponse() = """
+    {
+      "data": {
+        "enhetId": "4863",
+        "enhetNavn": "Enhet 4863"
+      },
+      "status": "SUKSESS",
+      "melding": "Innhenting av data var vellykket",
+      "frontendFeilmelding": null,
+      "stacktrace": null
+    }                                   
+        """
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseKontantstøtteRutingTaskTest.kt
@@ -9,6 +9,7 @@ import io.mockk.slot
 import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.domene.personopplysning.Person
+import no.nav.familie.baks.mottak.integrasjoner.ArbeidsfordelingClient
 import no.nav.familie.baks.mottak.integrasjoner.BarnDto
 import no.nav.familie.baks.mottak.integrasjoner.Bruker
 import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
@@ -56,6 +57,9 @@ class JournalhendelseKontantstøtteRutingTaskTest {
 
     @MockK
     private lateinit var unleashService: UnleashNextMedContextService
+
+    @MockK
+    private lateinit var arbeidsfordelingClient: ArbeidsfordelingClient
 
     @InjectMockKs
     private lateinit var journalhendelseKontantstøtteRutingTask: JournalhendelseKontantstøtteRutingTask

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/NavnoHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/NavnoHendelseTaskLøypeTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.integrasjoner.ArbeidsfordelingClient
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.Bruker
 import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
@@ -42,6 +43,7 @@ class NavnoHendelseTaskLøypeTest {
     private val mockPdlClient: PdlClient = mockk(relaxed = true)
     private val mockInfotrygdBarnetrygdClient: InfotrygdBarnetrygdClient = mockk()
     private val mockUnleashNextMedContextService: UnleashNextMedContextService = mockk()
+    private val mockkArbeidsfordelingClient: ArbeidsfordelingClient = mockk()
 
     private val rutingSteg =
         JournalhendelseBarnetrygdRutingTask(
@@ -51,6 +53,7 @@ class NavnoHendelseTaskLøypeTest {
             mockTaskService,
             mockUnleashNextMedContextService,
             mockJournalpostClient,
+            mockkArbeidsfordelingClient,
         )
 
     private val journalføringSteg =

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/SkanHendelseTaskLøypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/SkanHendelseTaskLøypeTest.kt
@@ -7,6 +7,7 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.hendelser.JournalføringHendelseServiceTest
+import no.nav.familie.baks.mottak.integrasjoner.ArbeidsfordelingClient
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.Bruker
 import no.nav.familie.baks.mottak.integrasjoner.BrukerIdType
@@ -42,6 +43,7 @@ class SkanHendelseTaskLøypeTest {
     private val mockPdlClient: PdlClient = mockk(relaxed = true)
     private val mockInfotrygdBarnetrygdClient: InfotrygdBarnetrygdClient = mockk()
     private val mockUnleashNextMedContextService: UnleashNextMedContextService = mockk()
+    private val mockkArbeidsfordelingClient: ArbeidsfordelingClient = mockk()
 
     private val rutingSteg =
         JournalhendelseBarnetrygdRutingTask(
@@ -51,6 +53,7 @@ class SkanHendelseTaskLøypeTest {
             mockTaskService,
             mockUnleashNextMedContextService,
             mockJournalpostClient,
+            mockkArbeidsfordelingClient,
         )
 
     private val journalføringSteg =


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21062

Når vi sjekker etter enhet så må vi gjøre dette på personen.
Dette er fordi at ved automatiske journalføringer blir enhet satt til 9999, så man kan ikke sjekke på journalpost.enhet