### PR TITLE
Tar i bruk ny versjon av BarnetrygdSøknad og KontantstøtteSøknad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20240809130157_d33fbc4</prosessering.version>
 
         <felles.version>3.20240806111424_fff2930</felles.version>
-        <kontrakter.version>3.0_20240816073331_933df6f</kontrakter.version>
+        <kontrakter.version>3.0_20240828135916_7c54c82</kontrakter.version>
         <main-class>no.nav.familie.baks.mottak.LauncherKt</main-class>
         <spring.cloud.version>4.1.4</spring.cloud.version>
         <token-validation-spring.version>5.0.2</token-validation-spring.version>
@@ -414,7 +414,8 @@
                         <phase>verify</phase>
                         <configuration>
                             <target name="ktlint">
-                                <java taskname="ktlint" dir="${basedir}" fork="true" failonerror="true" classpathref="maven.plugin.classpath" classname="com.pinterest.ktlint.Main">
+                                <java taskname="ktlint" dir="${basedir}" fork="true" failonerror="true"
+                                      classpathref="maven.plugin.classpath" classname="com.pinterest.ktlint.Main">
                                     <arg value="src/**/*.kt"/>
                                 </java>
                             </target>
@@ -428,7 +429,8 @@
                         <phase>validate</phase>
                         <configuration>
                             <target name="ktlint">
-                                <java taskname="ktlint" dir="${basedir}" fork="true" failonerror="true" classpathref="maven.plugin.classpath" classname="com.pinterest.ktlint.Main">
+                                <java taskname="ktlint" dir="${basedir}" fork="true" failonerror="true"
+                                      classpathref="maven.plugin.classpath" classname="com.pinterest.ktlint.Main">
                                     <jvmarg value="--add-opens"/>
                                     <jvmarg value="java.base/java.lang=ALL-UNNAMED"/>
                                     <arg value="-F"/>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>no.nav.familie</groupId>
             <artifactId>baks-dokgen</artifactId>
-            <version>1.0_20240627141649_53c4360</version>
+            <version>1.0_20240829133759_de4a212</version>
         </dependency>
         <!-- Kafka -->
         <dependency>

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/ArkiverDokumentRequestMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/ArkiverDokumentRequestMapper.kt
@@ -1,14 +1,16 @@
 package no.nav.familie.baks.mottak.søknad
 
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknaddokumentasjon
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBVedlegg
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.Vedlegg
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstotteVedlegg
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknaddokumentasjon
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
@@ -31,10 +33,16 @@ object ArkiverDokumentRequestMapper {
     ): ArkiverDokumentRequest {
         val (søknadstype, dokumentasjon) =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 ->
+                is BarnetrygdSøknadV8 ->
                     Pair(
-                        versjonertBarnetrygdSøknad.søknad.søknadstype,
-                        versjonertBarnetrygdSøknad.søknad.dokumentasjon.map { BarnetrygdSøknaddokumentasjon(it) },
+                        versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype,
+                        versjonertBarnetrygdSøknad.barnetrygdSøknad.dokumentasjon.map { BarnetrygdSøknaddokumentasjon(it) },
+                    )
+
+                is BarnetrygdSøknadV9 ->
+                    Pair(
+                        versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype,
+                        versjonertBarnetrygdSøknad.barnetrygdSøknad.dokumentasjon.map { BarnetrygdSøknaddokumentasjon(it) },
                     )
             }
 
@@ -94,6 +102,9 @@ object ArkiverDokumentRequestMapper {
         val dokumentasjon =
             when (versjonertSøknad) {
                 is KontantstøtteSøknadV4 ->
+                    versjonertSøknad.kontantstøtteSøknad.dokumentasjon.map { KontantstøtteSøknaddokumentasjon(it) }
+
+                is KontantstøtteSøknadV5 ->
                     versjonertSøknad.kontantstøtteSøknad.dokumentasjon.map { KontantstøtteSøknaddokumentasjon(it) }
             }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/PdfService.kt
@@ -1,11 +1,13 @@
 package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.integrasjoner.PdfClient
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import org.slf4j.LoggerFactory
@@ -30,9 +32,11 @@ class PdfService(
 
         val (søknadstype, navn) =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 -> {
-                    Pair(versjonertBarnetrygdSøknad.søknad.søknadstype, versjonertBarnetrygdSøknad.søknad.søker.navn)
-                }
+                is BarnetrygdSøknadV8 ->
+                    Pair(versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype, versjonertBarnetrygdSøknad.barnetrygdSøknad.søker.navn)
+
+                is BarnetrygdSøknadV9 ->
+                    Pair(versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype, versjonertBarnetrygdSøknad.barnetrygdSøknad.søker.navn)
             }
 
         val path: String = søknadstypeTilPath(søknadstype)
@@ -47,7 +51,6 @@ class PdfService(
                         else -> "Søknad om ordinær barnetrygd"
                     },
             )
-
         return familieDokumentPdfClient.lagPdf(path, barnetrygdSøknadMapForSpråk + ekstraFelterMap)
     }
 
@@ -62,6 +65,7 @@ class PdfService(
         val navn =
             when (versjonertSøknad) {
                 is KontantstøtteSøknadV4 -> versjonertSøknad.kontantstøtteSøknad.søker.navn
+                is KontantstøtteSøknadV5 -> versjonertSøknad.kontantstøtteSøknad.søker.navn
             }
 
         val ekstraFelterMap =
@@ -71,7 +75,6 @@ class PdfService(
                 fnr = dbKontantstøtteSøknad.fnr,
                 label = "Søknad om kontantstøtte",
             )
-
         return familieDokumentPdfClient.lagPdf("kontantstotte-soknad", kontantstøtteSøknadMapForSpråk + ekstraFelterMap)
     }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/SøknadSpråkvelgerService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/SøknadSpråkvelgerService.kt
@@ -3,10 +3,12 @@ package no.nav.familie.baks.mottak.søknad
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
 import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadObjectMapperModule
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteObjectMapperModule
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
 import org.springframework.stereotype.Service
 import no.nav.familie.kontrakter.felles.objectMapper as getObjectMapper
@@ -22,12 +24,14 @@ class SøknadSpråkvelgerService {
         val barnetrygdSøknadMapForSpråk =
             objectMapperForSpråk.convertValue<MutableMap<String, Any>>(
                 when (versjonertBarnetrygdSøknad) {
-                    is SøknadV8 -> versjonertBarnetrygdSøknad.søknad
+                    is BarnetrygdSøknadV8 -> versjonertBarnetrygdSøknad.barnetrygdSøknad
+                    is BarnetrygdSøknadV9 -> versjonertBarnetrygdSøknad.barnetrygdSøknad
                 },
             )
         barnetrygdSøknadMapForSpråk["teksterUtenomSpørsmål"] =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 -> versjonertBarnetrygdSøknad.søknad.teksterUtenomSpørsmål
+                is BarnetrygdSøknadV8 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.teksterUtenomSpørsmål
+                is BarnetrygdSøknadV9 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.teksterUtenomSpørsmål
             }.mapValues { it.value[språk] }
 
         return barnetrygdSøknadMapForSpråk
@@ -43,6 +47,7 @@ class SøknadSpråkvelgerService {
             objectMapperForSpråk.convertValue<MutableMap<String, Any>>(
                 when (versjonertSøknad) {
                     is KontantstøtteSøknadV4 -> versjonertSøknad.kontantstøtteSøknad
+                    is KontantstøtteSøknadV5 -> versjonertSøknad.kontantstøtteSøknad
                 },
             )
         return kontantstøtteSøknadMapForSpråk

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadController.kt
@@ -1,9 +1,12 @@
 package no.nav.familie.baks.mottak.søknad.barnetrygd
 
 import no.nav.familie.baks.mottak.søknad.Kvittering
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.FødselsnummerErNullException
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
+import no.nav.familie.kontrakter.ba.søknad.v8.Søknad
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
@@ -15,7 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadKontraktV8
 
 @RestController
 @RequestMapping(path = ["/api"], produces = [APPLICATION_JSON_VALUE])
@@ -26,9 +28,20 @@ class BarnetrygdSøknadController(
 ) {
     @PostMapping(value = ["/soknad/v8"], consumes = [MULTIPART_FORM_DATA_VALUE])
     fun taImotSøknad(
-        @RequestPart("søknad") søknad: SøknadKontraktV8,
+        @RequestPart("søknad") søknad: Søknad,
     ): ResponseEntity<Ressurs<Kvittering>> =
-        mottaVersjonertSøknadOgSendMetrikker(versjonertBarnetrygdSøknad = SøknadV8(søknad = søknad))
+        mottaVersjonertSøknadOgSendMetrikker(
+            versjonertBarnetrygdSøknad = BarnetrygdSøknadV8(barnetrygdSøknad = søknad),
+        )
+
+    @PostMapping(value = ["/soknad/v9"], consumes = [MULTIPART_FORM_DATA_VALUE])
+    fun taImotSøknad(
+        @RequestPart("søknad") søknad: BarnetrygdSøknad,
+    ): ResponseEntity<Ressurs<Kvittering>> =
+        mottaVersjonertSøknadOgSendMetrikker(
+            versjonertBarnetrygdSøknad =
+                BarnetrygdSøknadV9(barnetrygdSøknad = søknad),
+        )
 
     fun mottaVersjonertSøknadOgSendMetrikker(versjonertBarnetrygdSøknad: VersjonertBarnetrygdSøknad): ResponseEntity<Ressurs<Kvittering>> =
         try {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadMetrikkService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadMetrikkService.kt
@@ -1,7 +1,8 @@
 package no.nav.familie.baks.mottak.søknad.barnetrygd
 
 import io.micrometer.core.instrument.Metrics
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov
@@ -38,12 +39,14 @@ class BarnetrygdSøknadMetrikkService {
     fun sendMottakMetrikker(versjonertBarnetrygdSøknad: VersjonertBarnetrygdSøknad) {
         val (søknadstype, dokumentasjon) =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 -> Pair(versjonertBarnetrygdSøknad.søknad.søknadstype, versjonertBarnetrygdSøknad.søknad.dokumentasjon)
+                is BarnetrygdSøknadV8 -> Pair(versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype, versjonertBarnetrygdSøknad.barnetrygdSøknad.dokumentasjon)
+                is BarnetrygdSøknadV9 -> Pair(versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype, versjonertBarnetrygdSøknad.barnetrygdSøknad.dokumentasjon)
             }
 
         val harEøsSteg =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 -> versjonertBarnetrygdSøknad.søknad.antallEøsSteg > 0
+                is BarnetrygdSøknadV8 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.antallEøsSteg > 0
+                is BarnetrygdSøknadV9 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.antallEøsSteg > 0
             }
 
         val erUtvidet = søknadstype == Søknadstype.UTVIDET
@@ -55,7 +58,8 @@ class BarnetrygdSøknadMetrikkService {
     fun sendMottakFeiletMetrikker(versjonertBarnetrygdSøknad: VersjonertBarnetrygdSøknad) {
         val søknadstype =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 -> versjonertBarnetrygdSøknad.søknad.søknadstype
+                is BarnetrygdSøknadV8 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype
+                is BarnetrygdSøknadV9 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype
             }
         if (søknadstype == Søknadstype.UTVIDET) søknadUtvidetMottattFeil.increment() else søknadMottattFeil.increment()
     }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/BarnetrygdSøknadService.kt
@@ -1,11 +1,12 @@
 package no.nav.familie.baks.mottak.søknad.barnetrygd
 
 import no.nav.familie.baks.mottak.integrasjoner.FamilieDokumentClient
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBVedlegg
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.FødselsnummerErNullException
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadVedleggRepository
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
@@ -30,8 +31,12 @@ class BarnetrygdSøknadService(
     fun motta(versjonertBarnetrygdSøknad: VersjonertBarnetrygdSøknad): DBBarnetrygdSøknad {
         val (dbSøknad, dokumentasjon) =
             when (versjonertBarnetrygdSøknad) {
-                is SøknadV8 -> {
-                    Pair(versjonertBarnetrygdSøknad.søknad.tilDBSøknad(), versjonertBarnetrygdSøknad.søknad.dokumentasjon)
+                is BarnetrygdSøknadV8 -> {
+                    Pair(versjonertBarnetrygdSøknad.barnetrygdSøknad.tilDBSøknad(), versjonertBarnetrygdSøknad.barnetrygdSøknad.dokumentasjon)
+                }
+
+                is BarnetrygdSøknadV9 -> {
+                    Pair(versjonertBarnetrygdSøknad.barnetrygdSøknad.tilDBSøknad(), versjonertBarnetrygdSøknad.barnetrygdSøknad.dokumentasjon)
                 }
             }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/domene/VersjonertBarnetrygdSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/domene/VersjonertBarnetrygdSøknad.kt
@@ -1,9 +1,14 @@
 package no.nav.familie.baks.mottak.søknad.barnetrygd.domene
 
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadV8
+import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad as BarnetrygdSøknadV9
 
 sealed class VersjonertBarnetrygdSøknad
 
-data class SøknadV8(
-    val søknad: SøknadV8,
+data class BarnetrygdSøknadV8(
+    val barnetrygdSøknad: BarnetrygdSøknadV8,
+) : VersjonertBarnetrygdSøknad()
+
+data class BarnetrygdSøknadV9(
+    val barnetrygdSøknad: BarnetrygdSøknadV9,
 ) : VersjonertBarnetrygdSøknad()

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.baks.mottak.søknad.kontantstøtte
 import no.nav.familie.baks.mottak.søknad.Kvittering
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.FødselsnummerErNullException
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad as KontantstøtteSøknadKontraktV4
+import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad as KontantstøtteSøknadKontraktV5
 
 @RestController
 @RequestMapping(path = ["/api/kontantstotte/"], produces = [APPLICATION_JSON_VALUE])
@@ -29,6 +31,12 @@ class KontantstøtteSøknadController(
         @RequestPart("søknad") søknad: KontantstøtteSøknadKontraktV4,
     ): ResponseEntity<Ressurs<Kvittering>> =
         mottaVersjonertSøknadOgSendMetrikker(versjonertKontantstøtteSøknad = KontantstøtteSøknadV4(kontantstøtteSøknad = søknad))
+
+    @PostMapping(value = ["/soknad/v5"], consumes = [MULTIPART_FORM_DATA_VALUE])
+    fun taImotSøknad(
+        @RequestPart("søknad") søknad: KontantstøtteSøknadKontraktV5,
+    ): ResponseEntity<Ressurs<Kvittering>> =
+        mottaVersjonertSøknadOgSendMetrikker(versjonertKontantstøtteSøknad = KontantstøtteSøknadV5(kontantstøtteSøknad = søknad))
 
     fun mottaVersjonertSøknadOgSendMetrikker(versjonertKontantstøtteSøknad: VersjonertKontantstøtteSøknad): ResponseEntity<Ressurs<Kvittering>> =
         try {

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadMetrikkService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadMetrikkService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.baks.mottak.søknad.kontantstøtte
 
 import io.micrometer.core.instrument.Metrics
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
 import no.nav.familie.kontrakter.ks.søknad.v1.Dokumentasjonsbehov
 import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
@@ -25,11 +26,13 @@ class KontantstøtteSøknadMetrikkService {
         val dokumentasjon =
             when (versjonertKontantstøtteSøknad) {
                 is KontantstøtteSøknadV4 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.dokumentasjon
+                is KontantstøtteSøknadV5 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.dokumentasjon
             }
 
         val harEøsSteg =
             when (versjonertKontantstøtteSøknad) {
                 is KontantstøtteSøknadV4 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.antallEøsSteg > 0
+                is KontantstøtteSøknadV5 -> versjonertKontantstøtteSøknad.kontantstøtteSøknad.antallEøsSteg > 0
             }
 
         sendSøknadMetrikker(harEøsSteg)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtte
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.FødselsnummerErNullException
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteVedleggRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.VersjonertKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.tilDBKontantstøtteSøknad
@@ -18,7 +19,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.Properties
 
-@Service class KontantstøtteSøknadService(
+@Service
+class KontantstøtteSøknadService(
     private val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
     private val kontantstøtteVedleggRepository: KontantstøtteVedleggRepository,
     private val taskService: TaskService,
@@ -30,6 +32,13 @@ import java.util.Properties
         val (dbKontantstøtteSøknad, dokumentasjon) =
             when (versjonertKontantstøtteSøknad) {
                 is KontantstøtteSøknadV4 -> {
+                    Pair(
+                        versjonertKontantstøtteSøknad.kontantstøtteSøknad.tilDBKontantstøtteSøknad(),
+                        versjonertKontantstøtteSøknad.kontantstøtteSøknad.dokumentasjon,
+                    )
+                }
+
+                is KontantstøtteSøknadV5 -> {
                     Pair(
                         versjonertKontantstøtteSøknad.kontantstøtteSøknad.tilDBKontantstøtteSøknad(),
                         versjonertKontantstøtteSøknad.kontantstøtteSøknad.dokumentasjon,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/DBKontantstøtteSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/DBKontantstøtteSøknad.kt
@@ -34,25 +34,12 @@ data class DBKontantstøtteSøknad(
     @Column(name = "journalpost_id")
     val journalpostId: String? = null,
 ) {
-    private fun hentSøknadV5(): KontantstøtteSøknadV5 = objectMapper.readValue(søknadJson)
-
-    private fun hentSøknadV4(): KontantstøtteSøknadV4 = objectMapper.readValue(søknadJson)
-
-    private fun hentSøknadVersjon(): String {
-        val søknad = objectMapper.readTree(søknadJson)
-        val kontraktversjon = søknad.get("kontraktVersjon")?.asInt()
-        return when (kontraktversjon) {
-            4 -> "v4"
-            5 -> "v5"
-            else -> "v$kontraktversjon"
-        }
-    }
-
     fun hentVersjonertKontantstøtteSøknad(): VersjonertKontantstøtteSøknad {
-        val versjon = this.hentSøknadVersjon()
+        val søknad = objectMapper.readTree(søknadJson)
+        val versjon = søknad.get("kontraktVersjon")?.asInt()
         return when (versjon) {
-            "v5" -> KontantstøtteSøknadV5(kontantstøtteSøknad = hentSøknadV5())
-            "v4" -> KontantstøtteSøknadV4(kontantstøtteSøknad = hentSøknadV4())
+            4 -> KontantstøtteSøknadV4(kontantstøtteSøknad = objectMapper.readValue<KontantstøtteSøknadV4>(søknadJson))
+            5 -> KontantstøtteSøknadV5(kontantstøtteSøknad = objectMapper.readValue<KontantstøtteSøknadV5>(søknadJson))
             else -> error("Ikke støttet versjon $versjon av kontrakt for Kontantstøtte")
         }
     }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/VersjonertKontantstøtteSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/VersjonertKontantstøtteSøknad.kt
@@ -1,9 +1,14 @@
 package no.nav.familie.baks.mottak.søknad.kontantstøtte.domene
 
 import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad as KontantstøtteSøknadV4
+import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad as KontantstøtteSøknadV5
 
 sealed class VersjonertKontantstøtteSøknad
 
 data class KontantstøtteSøknadV4(
     val kontantstøtteSøknad: KontantstøtteSøknadV4,
+) : VersjonertKontantstøtteSøknad()
+
+data class KontantstøtteSøknadV5(
+    val kontantstøtteSøknad: KontantstøtteSøknadV5,
 ) : VersjonertKontantstøtteSøknad()

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførKontantstøtteSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførKontantstøtteSøknadTask.kt
@@ -5,6 +5,7 @@ import no.nav.familie.baks.mottak.søknad.PdfService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -45,6 +46,7 @@ class JournalførKontantstøtteSøknadTask(
             val orginalspråk =
                 when (versjonertSøknad) {
                     is KontantstøtteSøknadV4 -> versjonertSøknad.kontantstøtteSøknad.originalSpråk
+                    is KontantstøtteSøknadV5 -> versjonertSøknad.kontantstøtteSøknad.originalSpråk
                 }
 
             val orginalspråkPdf: ByteArray =

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalførSøknadTask.kt
@@ -2,9 +2,10 @@ package no.nav.familie.baks.mottak.task
 
 import no.nav.familie.baks.mottak.søknad.JournalføringService
 import no.nav.familie.baks.mottak.søknad.PdfService
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.VersjonertBarnetrygdSøknad
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -32,7 +33,8 @@ class JournalførSøknadTask(
 
             val søknadstype =
                 when (versjonertBarnetrygdSøknad) {
-                    is SøknadV8 -> versjonertBarnetrygdSøknad.søknad.søknadstype
+                    is BarnetrygdSøknadV8 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype
+                    is BarnetrygdSøknadV9 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.søknadstype
                 }
             log.info("Generer pdf og journalfør søknad om ${søknadstype.name.lowercase()} barnetrygd")
             val bokmålPdf =
@@ -45,7 +47,8 @@ class JournalførSøknadTask(
 
             val orginalspråk =
                 when (versjonertBarnetrygdSøknad) {
-                    is SøknadV8 -> versjonertBarnetrygdSøknad.søknad.originalSpråk
+                    is BarnetrygdSøknadV8 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.originalSpråk
+                    is BarnetrygdSøknadV9 -> versjonertBarnetrygdSøknad.barnetrygdSøknad.originalSpråk
                 }
 
             val orginalspråkPdf: ByteArray =

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/ArkiverDokumentRequestMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/ArkiverDokumentRequestMapperTest.kt
@@ -3,20 +3,20 @@ package no.nav.familie.baks.mottak.søknad
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBVedlegg
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstotteVedlegg
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
-import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
 import no.nav.familie.kontrakter.ks.søknad.v1.Dokumentasjonsbehov
 import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ks.søknad.v1.TekstPåSpråkMap
-import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad
+import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
@@ -57,7 +57,7 @@ class ArkiverDokumentRequestMapperTest {
         val arkiverDokumentRequest =
             ArkiverDokumentRequestMapper.toDto(
                 dbKontantstøtteSøknad,
-                KontantstøtteSøknadV4(kontantstøtteSøknad = kontantstøtteSøknad),
+                KontantstøtteSøknadV5(kontantstøtteSøknad = kontantstøtteSøknad),
                 ByteArray(0),
                 vedleggMap,
                 ByteArray(0),
@@ -89,7 +89,7 @@ class ArkiverDokumentRequestMapperTest {
 
     @Test
     fun `toDto - skal opprette ArkiverDokumentRequest basert på BarnetrygdSøknad`() {
-        val søknad: Søknad = mockk()
+        val barnetrygdSøknad: BarnetrygdSøknad = mockk()
         val dokumentasjon =
             no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon(
                 no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov.AVTALE_DELT_BOSTED,
@@ -109,11 +109,11 @@ class ArkiverDokumentRequestMapperTest {
                     ),
                 ),
             )
-        every { søknad.dokumentasjon } returns
+        every { barnetrygdSøknad.dokumentasjon } returns
             listOf(
                 dokumentasjon,
             )
-        every { søknad.søknadstype } returns Søknadstype.ORDINÆR
+        every { barnetrygdSøknad.søknadstype } returns Søknadstype.ORDINÆR
 
         val dbBarnetrygdSøknad = DBBarnetrygdSøknad(søknadJson = "{}", fnr = "12345678910")
         val vedleggMap =
@@ -123,7 +123,7 @@ class ArkiverDokumentRequestMapperTest {
         val arkiverDokumentRequest =
             ArkiverDokumentRequestMapper.toDto(
                 dbBarnetrygdSøknad,
-                BarnetrygdSøknadV8(søknad),
+                BarnetrygdSøknadV9(barnetrygdSøknad),
                 ByteArray(0),
                 vedleggMap,
                 ByteArray(0),

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/ArkiverDokumentRequestMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/ArkiverDokumentRequestMapperTest.kt
@@ -3,9 +3,9 @@ package no.nav.familie.baks.mottak.søknad
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBVedlegg
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstotteVedlegg
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
@@ -123,7 +123,7 @@ class ArkiverDokumentRequestMapperTest {
         val arkiverDokumentRequest =
             ArkiverDokumentRequestMapper.toDto(
                 dbBarnetrygdSøknad,
-                SøknadV8(søknad),
+                BarnetrygdSøknadV8(søknad),
                 ByteArray(0),
                 vedleggMap,
                 ByteArray(0),

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/EksternReferanseIdTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/EksternReferanseIdTest.kt
@@ -28,7 +28,7 @@ class EksternReferanseIdTest(
     @Autowired
     val journalførSøknadTask: JournalførSøknadTask,
 ) {
-    val søknad = SøknadTestData.søknadV8()
+    val søknad = SøknadTestData.barnetrygdSøknad()
     val dbSøknad = søknad.tilDBSøknad()
 
     @Test

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/JournalføringTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/JournalføringTest.kt
@@ -31,7 +31,7 @@ class JournalføringTest(
     @Autowired
     val kontantstøtteSøknadService: KontantstøtteSøknadService,
 ) {
-    val søknad = SøknadTestData.søknadV8()
+    val søknad = SøknadTestData.barnetrygdSøknad()
     val dbSøknad = søknad.tilDBSøknad()
     val kontantstøtteSøknad = KontantstøtteSøknadTestData.kontantstøtteSøknad()
     val dbKontantstøtteSøknad = kontantstøtteSøknad.tilDBKontantstøtteSøknad()

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/PdfServiceTest.kt
@@ -8,14 +8,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.baks.mottak.integrasjoner.PdfClient
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.io.File
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadKontraktV8
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class PdfServiceTest {
@@ -36,9 +36,9 @@ internal class PdfServiceTest {
         val jsonString: String =
             File("./src/test/kotlin/no/nav/familie/baks/mottak/søknad/testdata/testdata1.json")
                 .readText(Charsets.UTF_8)
-        val søknad: SøknadKontraktV8 = mapper.readValue(jsonString)
-        val dbBarnetrygdSøknad: DBBarnetrygdSøknad = søknad.tilDBSøknad()
-        pdfService.lagBarnetrygdPdf(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), dbBarnetrygdSøknad, språk = "nb")
+        val barnetrygdSøknad: BarnetrygdSøknad = mapper.readValue(jsonString)
+        val dbBarnetrygdSøknad: DBBarnetrygdSøknad = barnetrygdSøknad.tilDBSøknad()
+        pdfService.lagBarnetrygdPdf(BarnetrygdSøknadV9(barnetrygdSøknad = barnetrygdSøknad), dbBarnetrygdSøknad, språk = "nb")
 
         // Kommenter inn dette for å logge generert json til console
         // val jsonToDokgen: String = mapper.writeValueAsString(jsonSlot)

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/PdfServiceTest.kt
@@ -44,6 +44,6 @@ internal class PdfServiceTest {
         // val jsonToDokgen: String = mapper.writeValueAsString(jsonSlot)
         // println(jsonToDokgen)
 
-        assertThat(jsonSlot.captured["kontraktVersjon"]).isEqualTo(8)
+        assertThat(jsonSlot.captured["kontraktVersjon"]).isEqualTo(9)
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/PdfServiceTest.kt
@@ -8,8 +8,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.baks.mottak.integrasjoner.PdfClient
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -38,7 +38,7 @@ internal class PdfServiceTest {
                 .readText(Charsets.UTF_8)
         val søknad: SøknadKontraktV8 = mapper.readValue(jsonString)
         val dbBarnetrygdSøknad: DBBarnetrygdSøknad = søknad.tilDBSøknad()
-        pdfService.lagBarnetrygdPdf(SøknadV8(søknad = søknad), dbBarnetrygdSøknad, språk = "nb")
+        pdfService.lagBarnetrygdPdf(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), dbBarnetrygdSøknad, språk = "nb")
 
         // Kommenter inn dette for å logge generert json til console
         // val jsonToDokgen: String = mapper.writeValueAsString(jsonSlot)

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadSpråkvelgerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadSpråkvelgerServiceTest.kt
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV4
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadV5
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ks.søknad.v1.Søknadsfelt
 import no.nav.familie.kontrakter.ks.søknad.v1.TekstPåSpråkMap
 import no.nav.familie.kontrakter.ks.søknad.v4.Barn
-import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad
+import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
@@ -54,7 +54,7 @@ class SøknadSpråkvelgerServiceTest {
                 dokumentasjon,
             )
 
-        val versjonertKontantstøtteSøknad = KontantstøtteSøknadV4(kontantstøtteSøknad = kontantstøtteSøknad)
+        val versjonertKontantstøtteSøknad = KontantstøtteSøknadV5(kontantstøtteSøknad = kontantstøtteSøknad)
 
         // Bokmål
         var kontantstøtteMapForSpråk =

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.DevLauncherPostgres
 import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
 import no.nav.familie.baks.mottak.util.DbContainerInitializer
@@ -26,46 +26,46 @@ import kotlin.test.assertEquals
 class SøknadTest(
     @Autowired val barnetrygdSøknadService: BarnetrygdSøknadService,
 ) {
-    val søknadV8 = SøknadTestData.søknadV8()
+    val barnetrygdSøknad = SøknadTestData.barnetrygdSøknad()
 
     @Test
     fun `Lagring av søknad`() {
-        val dbSøknadFraMapper = søknadV8.tilDBSøknad()
-        assertThat(dbSøknadFraMapper.hentVersjonertSøknad() is BarnetrygdSøknadV8).isTrue
+        val dbSøknadFraMapper = barnetrygdSøknad.tilDBSøknad()
+        assertThat(dbSøknadFraMapper.hentVersjonertSøknad() is BarnetrygdSøknadV9).isTrue
 
         val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadFraMapper)
         val hentetSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
         assertEquals(dbSøknadFraDB.id, hentetSøknad!!.id)
-        assertThat(hentetSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV8)
+        assertThat(hentetSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV9)
     }
 
     @Test
-    fun `Få riktig versjon v8 ved mapping fra DBSøknad`() {
-        val dbSøknadFraMapper = søknadV8.tilDBSøknad()
+    fun `Få riktig versjon 9 ved mapping fra DBSøknad`() {
+        val dbSøknadFraMapper = barnetrygdSøknad.tilDBSøknad()
         val versjon: Int? =
             when (val versjonertSøknad = dbSøknadFraMapper.hentVersjonertSøknad()) {
-                is BarnetrygdSøknadV8 -> versjonertSøknad.barnetrygdSøknad.kontraktVersjon
+                is BarnetrygdSøknadV9 -> versjonertSøknad.barnetrygdSøknad.kontraktVersjon
                 else -> {
                     null
                 }
             }
-        assertEquals(søknadV8.kontraktVersjon, versjon)
+        assertEquals(barnetrygdSøknad.kontraktVersjon, versjon)
 
         val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadFraMapper)
         val hentetSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
         assertEquals(dbSøknadFraDB.id, hentetSøknad!!.id)
-        assertThat(hentetSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV8).isTrue
+        assertThat(hentetSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV9).isTrue
     }
 
     @Test
     fun `Version detection ved henting av søknad fra database`() {
-        val lagraV8SøknadData = objectMapper.writeValueAsString(SøknadTestData.søknadV8())
-        val v8DbBarnetrygdSøknad =
+        val barnetrygdSøknadSomString = objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad())
+        val DBBarnetrygdSøknad =
             DBBarnetrygdSøknad(
                 id = 2L,
-                søknadJson = lagraV8SøknadData,
+                søknadJson = barnetrygdSøknadSomString,
                 fnr = "1234123412",
             )
-        assertThat(v8DbBarnetrygdSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV8).isTrue
+        assertThat(DBBarnetrygdSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV9).isTrue
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
@@ -60,12 +60,12 @@ class SøknadTest(
     @Test
     fun `Version detection ved henting av søknad fra database`() {
         val barnetrygdSøknadSomString = objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad())
-        val DBBarnetrygdSøknad =
+        val dbBarnetrygdSøknad =
             DBBarnetrygdSøknad(
                 id = 2L,
                 søknadJson = barnetrygdSøknadSomString,
                 fnr = "1234123412",
             )
-        assertThat(DBBarnetrygdSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV9).isTrue
+        assertThat(dbBarnetrygdSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV9).isTrue
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTest.kt
@@ -2,8 +2,8 @@ package no.nav.familie.baks.mottak.søknad
 
 import no.nav.familie.baks.mottak.DevLauncherPostgres
 import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.tilDBSøknad
 import no.nav.familie.baks.mottak.util.DbContainerInitializer
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -31,12 +31,12 @@ class SøknadTest(
     @Test
     fun `Lagring av søknad`() {
         val dbSøknadFraMapper = søknadV8.tilDBSøknad()
-        assertThat(dbSøknadFraMapper.hentVersjonertSøknad() is SøknadV8).isTrue
+        assertThat(dbSøknadFraMapper.hentVersjonertSøknad() is BarnetrygdSøknadV8).isTrue
 
         val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadFraMapper)
         val hentetSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
         assertEquals(dbSøknadFraDB.id, hentetSøknad!!.id)
-        assertThat(hentetSøknad.hentVersjonertSøknad() is SøknadV8)
+        assertThat(hentetSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV8)
     }
 
     @Test
@@ -44,7 +44,7 @@ class SøknadTest(
         val dbSøknadFraMapper = søknadV8.tilDBSøknad()
         val versjon: Int? =
             when (val versjonertSøknad = dbSøknadFraMapper.hentVersjonertSøknad()) {
-                is SøknadV8 -> versjonertSøknad.søknad.kontraktVersjon
+                is BarnetrygdSøknadV8 -> versjonertSøknad.barnetrygdSøknad.kontraktVersjon
                 else -> {
                     null
                 }
@@ -54,7 +54,7 @@ class SøknadTest(
         val dbSøknadFraDB = barnetrygdSøknadService.lagreDBSøknad(dbSøknadFraMapper)
         val hentetSøknad = barnetrygdSøknadService.hentDBSøknad(dbSøknadFraDB.id)
         assertEquals(dbSøknadFraDB.id, hentetSøknad!!.id)
-        assertThat(hentetSøknad.hentVersjonertSøknad() is SøknadV8).isTrue
+        assertThat(hentetSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV8).isTrue
     }
 
     @Test
@@ -66,6 +66,6 @@ class SøknadTest(
                 søknadJson = lagraV8SøknadData,
                 fnr = "1234123412",
             )
-        assertThat(v8DbBarnetrygdSøknad.hentVersjonertSøknad() is SøknadV8).isTrue
+        assertThat(v8DbBarnetrygdSøknad.hentVersjonertSøknad() is BarnetrygdSøknadV8).isTrue
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTestData.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadTestData.kt
@@ -7,10 +7,10 @@ import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
 import no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknadsvedlegg
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt as SøknadsfeltV4
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn as BarnV8
 import no.nav.familie.kontrakter.ba.søknad.v8.Søker as SøkerV8
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as SøknadV8
 
 fun <T> søknadsfelt(
     label: String,
@@ -78,10 +78,10 @@ object SøknadTestData {
             ),
         )
 
-    fun søknadV8(): SøknadV8 =
-        SøknadV8(
+    fun barnetrygdSøknad(): BarnetrygdSøknad =
+        BarnetrygdSøknad(
             antallEøsSteg = 3,
-            kontraktVersjon = 8,
+            kontraktVersjon = 9,
             søknadstype = Søknadstype.ORDINÆR,
             søker = søkerV8(),
             barn = barnV8(),
@@ -104,5 +104,6 @@ object SøknadTestData {
                 ),
             originalSpråk = "nb",
             teksterUtenomSpørsmål = mapOf(),
+            finnesPersonMedAdressebeskyttelse = false,
         )
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadsfeltSpråkTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadsfeltSpråkTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.mottak.DevLauncherPostgres
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
 import no.nav.familie.baks.mottak.util.DbContainerInitializer
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
 import no.nav.familie.kontrakter.ba.søknad.v8.Søknad
@@ -50,11 +50,11 @@ class SøknadsfeltSpråkTest(
             )
         every { søknad.teksterUtenomSpørsmål } returns mapOf()
 
-        var barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(SøknadV8(søknad = søknad), "en")
+        var barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "en")
         var barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestAnswer", barnetrygdSøknadJsonNode["spørsmål"]["testSpørsmål"]["verdi"].textValue())
 
-        barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(SøknadV8(søknad = søknad), "nb")
+        barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "nb")
         barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestSvar", barnetrygdSøknadJsonNode["spørsmål"]["testSpørsmål"]["verdi"].textValue())
     }
@@ -133,7 +133,7 @@ class SøknadsfeltSpråkTest(
             )
         every { søknad.teksterUtenomSpørsmål } returns mapOf()
 
-        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(SøknadV8(søknad = søknad), "nb")
+        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "nb")
         val barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestNøstetVerdi", barnetrygdSøknadJsonNode["spørsmål"]["testSpørsmål"]["verdi"]["verdi"].textValue())
     }
@@ -151,7 +151,7 @@ class SøknadsfeltSpråkTest(
                     ),
             )
 
-        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(SøknadV8(søknad = søknad), "nb")
+        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "nb")
         val barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestTekst", barnetrygdSøknadJsonNode["teksterUtenomSpørsmål"]["test.tekst"].textValue())
     }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadsfeltSpråkTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/SøknadsfeltSpråkTest.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.mottak.DevLauncherPostgres
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV8
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.BarnetrygdSøknadV9
 import no.nav.familie.baks.mottak.util.DbContainerInitializer
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
-import no.nav.familie.kontrakter.ba.søknad.v8.Søknad
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -30,9 +30,9 @@ class SøknadsfeltSpråkTest(
 ) {
     @Test
     fun `Kan velge språk for søknadsfelter`() {
-        val søknad: Søknad = mockk()
-        every { søknad.originalSpråk } returns "nb"
-        every { søknad.spørsmål } returns
+        val barnetrygdSøknad: BarnetrygdSøknad = mockk()
+        every { barnetrygdSøknad.originalSpråk } returns "nb"
+        every { barnetrygdSøknad.spørsmål } returns
             mapOf(
                 "testSpørsmål" to
                     Søknadsfelt(
@@ -48,22 +48,22 @@ class SøknadsfeltSpråkTest(
                             ),
                     ),
             )
-        every { søknad.teksterUtenomSpørsmål } returns mapOf()
+        every { barnetrygdSøknad.teksterUtenomSpørsmål } returns mapOf()
 
-        var barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "en")
+        var barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV9(barnetrygdSøknad = barnetrygdSøknad), "en")
         var barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestAnswer", barnetrygdSøknadJsonNode["spørsmål"]["testSpørsmål"]["verdi"].textValue())
 
-        barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "nb")
+        barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV9(barnetrygdSøknad = barnetrygdSøknad), "nb")
         barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestSvar", barnetrygdSøknadJsonNode["spørsmål"]["testSpørsmål"]["verdi"].textValue())
     }
 
     @Test
     fun `Påvirker ikke global objectmapping`() {
-        val søknad: Søknad = mockk()
-        every { søknad.originalSpråk } returns "nb"
-        every { søknad.spørsmål } returns
+        val barnetrygdSøknad: BarnetrygdSøknad = mockk()
+        every { barnetrygdSøknad.originalSpråk } returns "nb"
+        every { barnetrygdSøknad.spørsmål } returns
             mapOf(
                 "testSpørsmål" to
                     Søknadsfelt(
@@ -80,7 +80,7 @@ class SøknadsfeltSpråkTest(
                     ),
             )
 
-        val asJson = objectMapper.writeValueAsString(søknad)
+        val asJson = objectMapper.writeValueAsString(barnetrygdSøknad)
         assertNotEquals(-1, asJson.indexOf("TestSpørsmål"))
         assertNotEquals(-1, asJson.indexOf("TestSvar"))
         assertNotEquals(-1, asJson.indexOf("TestQuestion"))
@@ -89,9 +89,9 @@ class SøknadsfeltSpråkTest(
 
     @Test
     fun `Håndterer nested SøknadsFelter korrekt`() {
-        val søknad: Søknad = mockk()
-        every { søknad.originalSpråk } returns "nb"
-        every { søknad.spørsmål } returns
+        val barnetrygdSøknad: BarnetrygdSøknad = mockk()
+        every { barnetrygdSøknad.originalSpråk } returns "nb"
+        every { barnetrygdSøknad.spørsmål } returns
             mapOf(
                 "testSpørsmål" to
                     Søknadsfelt(
@@ -131,18 +131,18 @@ class SøknadsfeltSpråkTest(
                             ),
                     ),
             )
-        every { søknad.teksterUtenomSpørsmål } returns mapOf()
+        every { barnetrygdSøknad.teksterUtenomSpørsmål } returns mapOf()
 
-        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "nb")
+        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV9(barnetrygdSøknad = barnetrygdSøknad), "nb")
         val barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestNøstetVerdi", barnetrygdSøknadJsonNode["spørsmål"]["testSpørsmål"]["verdi"]["verdi"].textValue())
     }
 
     @Test
     fun `Håndterer språkvalg for ekstratekster`() {
-        val søknad: Søknad = mockk()
-        every { søknad.originalSpråk } returns "nb"
-        every { søknad.teksterUtenomSpørsmål } returns
+        val barnetrygdSøknad: BarnetrygdSøknad = mockk()
+        every { barnetrygdSøknad.originalSpråk } returns "nb"
+        every { barnetrygdSøknad.teksterUtenomSpørsmål } returns
             mapOf(
                 "test.tekst" to
                     mapOf(
@@ -151,7 +151,7 @@ class SøknadsfeltSpråkTest(
                     ),
             )
 
-        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV8(barnetrygdSøknad = søknad), "nb")
+        val barnetrygdSøknadMap = søknadSpråkvelgerService.konverterBarnetrygdSøknadTilMapForSpråk(BarnetrygdSøknadV9(barnetrygdSøknad = barnetrygdSøknad), "nb")
         val barnetrygdSøknadJsonNode = objectMapper.valueToTree<JsonNode>(barnetrygdSøknadMap)
         assertEquals("TestTekst", barnetrygdSøknadJsonNode["teksterUtenomSpørsmål"]["test.tekst"].textValue())
     }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadTestData.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadTestData.kt
@@ -13,7 +13,7 @@ fun <T> søknadsfelt(
 object KontantstøtteSøknadTestData {
     fun kontantstøtteSøknad(): KontantstøtteSøknad =
         KontantstøtteSøknad(
-            kontraktVersjon = 4,
+            kontraktVersjon = 5,
             antallEøsSteg = 2,
             søker = lagSøker(),
             barn = emptyList(),

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadTestData.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/KontantstøtteSøknadTestData.kt
@@ -2,8 +2,8 @@ package no.nav.familie.baks.mottak.søknad.kontantstøtte
 
 import no.nav.familie.kontrakter.ks.søknad.v1.SIVILSTANDTYPE
 import no.nav.familie.kontrakter.ks.søknad.v1.Søknadsfelt
-import no.nav.familie.kontrakter.ks.søknad.v4.KontantstøtteSøknad
 import no.nav.familie.kontrakter.ks.søknad.v4.Søker
+import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad
 
 fun <T> søknadsfelt(
     label: String,
@@ -28,6 +28,7 @@ object KontantstøtteSøknadTestData {
             mottarKontantstøtteForBarnFraAnnetEøsland = søknadsfelt("Kontantstøtte annet land", "NEI"),
             harEllerTildeltBarnehageplass = søknadsfelt("Har barnehageplass", "NEI"),
             erAvdødPartnerForelder = null,
+            finnesPersonMedAdressebeskyttelse = false,
         )
 
     private fun lagSøker(): Søker =

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/testdata/dokgen/testdata_input.json
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/testdata/dokgen/testdata_input.json
@@ -1,5 +1,5 @@
 {
-  "kontraktVersjon": 8,
+  "kontraktVersjon": 9,
   "antallEøsSteg": 2,
   "søknadstype": "ORDINÆR",
   "søker": {

--- a/src/test/kotlin/no/nav/familie/baks/mottak/søknad/testdata/testdata1.json
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/søknad/testdata/testdata1.json
@@ -1,6 +1,6 @@
 {
   "søknadstype": "ORDINÆR",
-  "kontraktVersjon": 8,
+  "kontraktVersjon": 9,
   "antallEøsSteg": 2,
   "søker": {
     "harEøsSteg": true,


### PR DESCRIPTION
Favro: [NAV-22010](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22010)

Kontrakter for `BarnetrygdSøknad` og `KontantstøtteSøknad` er oppdatert i [familie-kontrakter](https://github.com/navikt/familie-kontrakter/pull/929). Legger her inn støtte for den nye versjonen gjennom nye endepunkter og øvrig håndtering av mottak. Vil nå støtte denne og forrige versjon av kontraktene til henholdsvis barnetrygd- og kontantstøtte -søknaden, slik at vi kan rulle ut alle backend endringer først uten nedetid for søknadsdialogen.

Store deler av PR er renaming av `Søknad` -> `BarnetrygdSøknad`.

Relaterte endringer: 
* [familie-kontrakter](https://github.com/navikt/familie-kontrakter/pull/929)
* [familie-baks-dokgen](https://github.com/navikt/familie-baks-dokgen/pull/191)
* [familie-baks-soknad-api](https://github.com/navikt/familie-baks-soknad-api/pull/283)

Skjermbilde av PDF når det finnes personer med adressebeskyttelse. Endringen er at adresse er satt til "Skjermet adresse":
![image](https://github.com/user-attachments/assets/0548bfeb-a073-4f15-8562-c84722ef6626)