### PR TITLE
NAV-23413: Fjerner toggle for EnhetsnummerService

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
@@ -8,6 +8,5 @@ class FeatureToggleConfig {
         // Release
         const val AUTOMATISK_JOURNALFØRING_AV_KONTANTSTØTTE_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ks-soknad"
         const val AUTOMATISK_JOURNALFØRING_AV_BARNETRYGD_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ba-soknad"
-        const val BRUK_ENHETSNUMMERSERVICE = "familie-baks-mottak.bruk-enhetsnummerservice"
     }
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -1,31 +1,21 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
-import no.nav.familie.baks.mottak.journalføring.JournalpostBrukerService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.harEøsSteg
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 
 @Service
 class BarnetrygdOppgaveMapper(
-    hentEnhetClient: HentEnhetClient,
-    unleashService: UnleashService,
     enhetsnummerService: EnhetsnummerService,
-    arbeidsfordelingClient: ArbeidsfordelingClient,
     pdlClient: PdlClient,
-    journalpostBrukerService: JournalpostBrukerService,
     val søknadRepository: SøknadRepository,
 ) : AbstractOppgaveMapper(
-        hentEnhetClient = hentEnhetClient,
-        unleashService = unleashService,
         enhetsnummerService = enhetsnummerService,
         pdlClient = pdlClient,
-        arbeidsfordelingClient = arbeidsfordelingClient,
-        journalpostBrukerService = journalpostBrukerService,
     ) {
     override val tema: Tema = Tema.BAR
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -1,31 +1,21 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
-import no.nav.familie.baks.mottak.journalføring.JournalpostBrukerService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.harEøsSteg
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
-import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 
 @Service
 class KontantstøtteOppgaveMapper(
-    hentEnhetClient: HentEnhetClient,
-    unleashService: UnleashService,
     enhetsnummerService: EnhetsnummerService,
-    arbeidsfordelingClient: ArbeidsfordelingClient,
     pdlClient: PdlClient,
-    journalpostBrukerService: JournalpostBrukerService,
     val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
 ) : AbstractOppgaveMapper(
-        hentEnhetClient = hentEnhetClient,
-        unleashService = unleashService,
         enhetsnummerService = enhetsnummerService,
         pdlClient = pdlClient,
-        arbeidsfordelingClient = arbeidsfordelingClient,
-        journalpostBrukerService = journalpostBrukerService,
     ) {
     override val tema: Tema = Tema.KON
 

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -3,8 +3,6 @@ package no.nav.familie.baks.mottak.integrasjoner
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.mottak.DevLauncher
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.journalføring.JournalpostBrukerService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -16,7 +14,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -39,38 +36,25 @@ class OppgaveMapperTest(
     @Autowired
     private val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
 ) {
-    private val mockUnleashService: UnleashService = mockk()
-    private val mockHentEnhetClient: HentEnhetClient = mockk(relaxed = true)
     private val mockEnhetsnummerService: EnhetsnummerService = mockk()
-    private val mockArbeidsfordelingClient: ArbeidsfordelingClient = mockk(relaxed = true)
-    private val mockJournalpostBrukerService: JournalpostBrukerService = mockk()
 
     private val barnetrygdOppgaveMapper: IOppgaveMapper =
         BarnetrygdOppgaveMapper(
-            hentEnhetClient = mockHentEnhetClient,
-            unleashService = mockUnleashService,
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             søknadRepository = barnetrygdSøknadRepository,
-            arbeidsfordelingClient = mockArbeidsfordelingClient,
-            journalpostBrukerService = mockJournalpostBrukerService,
         )
 
     private val kontantstøtteOppgaveMapper: IOppgaveMapper =
         KontantstøtteOppgaveMapper(
-            hentEnhetClient = mockHentEnhetClient,
-            unleashService = mockUnleashService,
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
-            arbeidsfordelingClient = mockArbeidsfordelingClient,
-            journalpostBrukerService = mockJournalpostBrukerService,
         )
 
     @BeforeEach
     fun beforeEach() {
         every { mockEnhetsnummerService.hentEnhetsnummer(any()) } returns "1234"
-        every { mockUnleashService.isEnabled(FeatureToggleConfig.BRUK_ENHETSNUMMERSERVICE) } returns true
     }
 
     @Test


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23413

Toggelen er på i prod og dev. Den kan nå fjernes. 

Venter noen dager med å merge for å være helt sikker på at vi ikke trenger å skru den av igjen.