### PR TITLE
Bumper familie-kontrakter for å få oppdatert SerDes av KontantstøtteSøknad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20241205111631_afe703f</prosessering.version>
 
         <felles.version>3.20241127123724_adfc561</felles.version>
-        <kontrakter.version>3.0_20241125142330_0a07b16</kontrakter.version>
+        <kontrakter.version>3.0_20241211134553_5cc5b4b</kontrakter.version>
 
         <main-class>no.nav.familie.baks.mottak.LauncherKt</main-class>
         <spring.cloud.version>4.2.0</spring.cloud.version>


### PR DESCRIPTION
Bumper familie-kontrakter slik at KontantstøtteSøknad er kompatibel med ny versjon av Jackson i Spring Boot 3.4.0