### PR TITLE
Reduserser open-telemtry logger pga samme kafka clientID på flere topic.

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/EnsligForsørgerInfotrygdHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/EnsligForsørgerInfotrygdHendelseConsumer.kt
@@ -65,6 +65,7 @@ class EnsligForsørgerInfotrygdHendelseConsumer(
         topics = ["teamfamilie.$TOPIC_INFOTRYGD_VEDTAK"],
         containerFactory = "kafkaAivenHendelseListenerContainerFactory",
         idIsGroup = false,
+        clientIdPrefix = "ef-infotrygd",
     )
     @Transactional
     fun listen(

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/EnsligForsørgerVedtakHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/EnsligForsørgerVedtakHendelseConsumer.kt
@@ -39,6 +39,7 @@ class EnsligForsørgerVedtakHendelseConsumer(
         topics = ["teamfamilie.$TOPIC_EF_VEDTAK"],
         containerFactory = "kafkaAivenHendelseListenerContainerFactory",
         idIsGroup = false,
+        clientIdPrefix = "ef-sak",
     )
     @Transactional
     fun listen(

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalføringHendelseAivenConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/JournalføringHendelseAivenConsumer.kt
@@ -30,6 +30,7 @@ class JournalføringHendelseAivenConsumer(
         topics = ["\${JOURNALFOERINGHENDELSE_V1_TOPIC_AIVEN_URL}"],
         containerFactory = "kafkaAivenHendelseListenerAvroLatestContainerFactory",
         idIsGroup = false,
+        clientIdPrefix = "jfr",
     )
     @Transactional
     fun listen(

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahConsumer.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahConsumer.kt
@@ -36,6 +36,7 @@ class LeesahConsumer(
         idIsGroup = false,
         containerFactory = "kafkaAivenHendelseListenerAvroEarliestContainerFactory",
         autoStartup = "true",
+        clientIdPrefix = "leesah",
     )
     @Transactional
     fun listen(


### PR DESCRIPTION
Fjerner logger til stdout av denne typen:
[otel.javaagent 2024-12-16 15:17:31:406 +0100] [PeriodicMetricReader-1] WARN io.opentelemetry.sdk.metrics.internal.state.AsynchronousMetricStorage - Instrument kafka.consumer.incoming_byte_rate has recorded multiple values for the same attributes: {client-id="consumer-familie-baks-mottak-2-0", node-id="node--1"}