### PR TITLE
NAV-23499: Håndtering av `bruker == null` ved opprettelse av Journalføringsoppgave 

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerService.kt
@@ -28,14 +28,8 @@ class EnhetsnummerService(
             logger.error("Journalpost tema er null for journalpost ${journalpost.journalpostId}.")
             throw IllegalStateException("Tema er null")
         }
-
-        val journalpostBruker = journalpost.bruker
-
-        if (journalpostBruker == null) {
-            logger.error("Bruker for journalpost ${journalpost.journalpostId} er null. Usikker på hvordan dette burde håndteres. Se SecureLogs.")
-            secureLogger.error("Bruker for journalpost $journalpost er null. Usikker på hvordan dette burde håndteres.")
-            throw IllegalStateException("Bruker for journalpost ${journalpost.journalpostId} er null. Usikker på hvordan dette burde håndteres.")
-        }
+        
+        val journalpostBruker = journalpost.bruker ?: return null
 
         val tema = Tema.valueOf(journalpostTema)
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerService.kt
@@ -28,7 +28,8 @@ class EnhetsnummerService(
             logger.error("Journalpost tema er null for journalpost ${journalpost.journalpostId}.")
             throw IllegalStateException("Tema er null")
         }
-        
+
+        // Kan ikke utlede enhet dersom bruker er null.
         val journalpostBruker = journalpost.bruker ?: return null
 
         val tema = Tema.valueOf(journalpostTema)

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerServiceTest.kt
@@ -359,8 +359,8 @@ class EnhetsnummerServiceTest {
         every {
             mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(any(), any())
         } returns
-                no.nav.familie.kontrakter.felles.arbeidsfordeling
-                    .Enhet(enhetId = "789", "Hønefoss")
+            no.nav.familie.kontrakter.felles.arbeidsfordeling
+                .Enhet(enhetId = "789", "Hønefoss")
         // Act
         val enhetsnummer = enhetsnummerService.hentEnhetsnummer(journalpost)
 

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/EnhetsnummerServiceTest.kt
@@ -303,7 +303,7 @@ class EnhetsnummerServiceTest {
     }
 
     @Test
-    fun `skal kaste exception hvis journalpost bruker er null`() {
+    fun `skal returnere null hvis journalpost bruker er null`() {
         // Arrange
         val journalpostId = "123"
 
@@ -320,12 +320,9 @@ class EnhetsnummerServiceTest {
             )
 
         // Act & Assert
-        val exception =
-            assertThrows<IllegalStateException> {
-                enhetsnummerService.hentEnhetsnummer(journalpost)
-            }
+        val enhetsnummer = enhetsnummerService.hentEnhetsnummer(journalpost)
 
-        assertThat(exception.message).isEqualTo("Bruker for journalpost $journalpostId er null. Usikker på hvordan dette burde håndteres.")
+        assertThat(enhetsnummer).isNull()
     }
 
     @ParameterizedTest
@@ -362,8 +359,8 @@ class EnhetsnummerServiceTest {
         every {
             mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(any(), any())
         } returns
-            no.nav.familie.kontrakter.felles.arbeidsfordeling
-                .Enhet(enhetId = "789", "Hønefoss")
+                no.nav.familie.kontrakter.felles.arbeidsfordeling
+                    .Enhet(enhetId = "789", "Hønefoss")
         // Act
         val enhetsnummer = enhetsnummerService.hentEnhetsnummer(journalpost)
 


### PR DESCRIPTION
Favro: [NAV-23499](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23499)

Dersom bruker er null, lar vi `ident` og `enhet` stå som `null` på `Journalføring`-oppgaven. Da vil oppgave-systemet, basert på arbeidsfordelingsregler, sette oppgaven til midlertidig enhet 4863 hvor saksbehandlere vil forsøke å finne ut hvem journalposten omhandler. Finner de ikke ut av det skal saksbehandler sende oppgaven videre til Fagpost på enhet 2950 (håndteres utenfor våre systemer).