### PR TITLE
Hent versjonert søknad for identer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250102104603_293d453</prosessering.version>
 
         <felles.version>3.20250106100611_6ae49d2</felles.version>
-        <kontrakter.version>3.0_20250110083551_c4fbcaf</kontrakter.version>
+        <kontrakter.version>3.0_20250121154645_1b256a5</kontrakter.version>
 
         <main-class>no.nav.familie.baks.mottak.LauncherKt</main-class>
         <spring.cloud.version>4.2.0</spring.cloud.version>

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknad
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknad
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.retry.annotation.Backoff
@@ -17,40 +16,38 @@ import java.net.URI
 private val logger = LoggerFactory.getLogger(BaksVersjonertSøknadClient::class.java)
 
 @Component
-class BaksVersjonertSøknadClient
-    @Autowired
-    constructor(
-        @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}")
-        private val integrasjonerServiceUri: URI,
-        @Qualifier("clientCredentials") restOperations: RestOperations,
-    ) : AbstractRestClient(restOperations, "integrasjon.saf") {
-        @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
-        fun hentVersjonertBarnetrygdSøknad(
-            journalpostId: String,
-        ): VersjonertBarnetrygdSøknad {
-            val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ba/$journalpostId")
-            logger.debug("henter søknad for barnetrygd med journalpostId: $journalpostId")
+class BaksVersjonertSøknadClient(
+    @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}")
+    private val integrasjonerServiceUri: URI,
+    @Qualifier("clientCredentials") restOperations: RestOperations,
+) : AbstractRestClient(restOperations, "integrasjon") {
+    @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
+    fun hentVersjonertBarnetrygdSøknad(
+        journalpostId: String,
+    ): VersjonertBarnetrygdSøknad {
+        val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ba/$journalpostId")
+        logger.debug("henter søknad for barnetrygd med journalpostId: $journalpostId")
 
-            return runCatching {
-                getForEntity<Ressurs<VersjonertBarnetrygdSøknad>>(uri)
-            }.fold(
-                onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
-                onFailure = { throw IntegrasjonException("Henting av søknad for barnetrygd feilet. journalpostId: $journalpostId", it, uri) },
-            )
-        }
-
-        @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
-        fun hentVersjonertKontantstøtteSøknad(
-            journalpostId: String,
-        ): VersjonertKontantstøtteSøknad {
-            val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ks/$journalpostId")
-            logger.debug("henter søknad for kontantstøtte med journalpostId: $journalpostId")
-
-            return runCatching {
-                getForEntity<Ressurs<VersjonertKontantstøtteSøknad>>(uri)
-            }.fold(
-                onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
-                onFailure = { throw IntegrasjonException("Henting av søknad for kontantstøtte feilet. journalpostId: $journalpostId.", it, uri) },
-            )
-        }
+        return runCatching {
+            getForEntity<Ressurs<VersjonertBarnetrygdSøknad>>(uri)
+        }.fold(
+            onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
+            onFailure = { throw IntegrasjonException("Henting av søknad for barnetrygd feilet. journalpostId: $journalpostId", it, uri) },
+        )
     }
+
+    @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
+    fun hentVersjonertKontantstøtteSøknad(
+        journalpostId: String,
+    ): VersjonertKontantstøtteSøknad {
+        val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ks/$journalpostId")
+        logger.debug("henter søknad for kontantstøtte med journalpostId: $journalpostId")
+
+        return runCatching {
+            getForEntity<Ressurs<VersjonertKontantstøtteSøknad>>(uri)
+        }.fold(
+            onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
+            onFailure = { throw IntegrasjonException("Henting av søknad for kontantstøtte feilet. journalpostId: $journalpostId.", it, uri) },
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknadV9
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknadV5
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+private val logger = LoggerFactory.getLogger(BaksVersjonertSøknadClient::class.java)
+
+@Component
+class BaksVersjonertSøknadClient
+    @Autowired
+    constructor(
+        @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}")
+        private val integrasjonerServiceUri: URI,
+        @Qualifier("clientCredentials") restOperations: RestOperations,
+    ) : AbstractRestClient(restOperations, "integrasjon.saf") {
+        @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
+        fun hentVersjonertBarnetrygdSøknad(
+            journalpostId: String,
+        ): VersjonertBarnetrygdSøknadV9 {
+            val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ba/$journalpostId")
+            logger.debug("henter søknad for barnetrygd med journalpostId: $journalpostId")
+
+            return runCatching {
+                getForEntity<Ressurs<VersjonertBarnetrygdSøknadV9>>(uri)
+            }.fold(
+                onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
+                onFailure = { throw IntegrasjonException("Henting av søknad for barnetrygd feilet. journalpostId: $journalpostId", it, uri) },
+            )
+        }
+
+        @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
+        fun hentVersjonertKontantstøtteSøknad(
+            journalpostId: String,
+        ): VersjonertKontantstøtteSøknadV5 {
+            val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ks/$journalpostId")
+            logger.debug("henter søknad for kontantstøtte med journalpostId: $journalpostId")
+
+            return runCatching {
+                getForEntity<Ressurs<VersjonertKontantstøtteSøknadV5>>(uri)
+            }.fold(
+                onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
+                onFailure = { throw IntegrasjonException("Henting av søknad for kontantstøtte feilet. journalpostId: $journalpostId.", it, uri) },
+            )
+        }
+    }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
 import no.nav.familie.http.client.AbstractRestClient
-import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknadV9
+import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknad
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknadV5
+import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknad
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -27,12 +27,12 @@ class BaksVersjonertSøknadClient
         @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
         fun hentVersjonertBarnetrygdSøknad(
             journalpostId: String,
-        ): VersjonertBarnetrygdSøknadV9 {
+        ): VersjonertBarnetrygdSøknad {
             val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ba/$journalpostId")
             logger.debug("henter søknad for barnetrygd med journalpostId: $journalpostId")
 
             return runCatching {
-                getForEntity<Ressurs<VersjonertBarnetrygdSøknadV9>>(uri)
+                getForEntity<Ressurs<VersjonertBarnetrygdSøknad>>(uri)
             }.fold(
                 onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
                 onFailure = { throw IntegrasjonException("Henting av søknad for barnetrygd feilet. journalpostId: $journalpostId", it, uri) },
@@ -42,12 +42,12 @@ class BaksVersjonertSøknadClient
         @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delayExpression = "\${retry.backoff.delay:5000}"))
         fun hentVersjonertKontantstøtteSøknad(
             journalpostId: String,
-        ): VersjonertKontantstøtteSøknadV5 {
+        ): VersjonertKontantstøtteSøknad {
             val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ks/$journalpostId")
             logger.debug("henter søknad for kontantstøtte med journalpostId: $journalpostId")
 
             return runCatching {
-                getForEntity<Ressurs<VersjonertKontantstøtteSøknadV5>>(uri)
+                getForEntity<Ressurs<VersjonertKontantstøtteSøknad>>(uri)
             }.fold(
                 onSuccess = { it.data ?: throw IntegrasjonException(it.melding, uri = uri) },
                 onFailure = { throw IntegrasjonException("Henting av søknad for kontantstøtte feilet. journalpostId: $journalpostId.", it, uri) },

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SøknadsidenterService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/SøknadsidenterService.kt
@@ -1,71 +1,22 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
-import no.nav.familie.baks.mottak.søknad.barnetrygd.BarnetrygdSøknadService
-import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadService
-import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknadV8
-import no.nav.familie.kontrakter.ba.søknad.VersjonertBarnetrygdSøknadV9
-import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknadV4
-import no.nav.familie.kontrakter.ks.søknad.VersjonertKontantstøtteSøknadV5
 import org.springframework.stereotype.Service
 
 @Service
 class SøknadsidenterService(
-    private val barnetrygdSøknadService: BarnetrygdSøknadService,
-    private val kontantstøtteSøknadService: KontantstøtteSøknadService,
+    private val baksVersjonertSøknadClient: BaksVersjonertSøknadClient,
 ) {
-    fun hentIdenterForKontantstøtteViaJournalpost(journalpostId: String): Pair<String, List<String>> {
-        val versjonertSøknad =
-            kontantstøtteSøknadService
-                .hentDBKontantstøtteSøknadForJournalpost(journalpostId)
-                .hentVersjonertKontantstøtteSøknad()
-        return when (versjonertSøknad) {
-            is VersjonertKontantstøtteSøknadV4 ->
-                Pair(
-                    versjonertSøknad.kontantstøtteSøknad.søker.ident.verdi.values
-                        .first(),
-                    versjonertSøknad.kontantstøtteSøknad.barn.map {
-                        it.ident.verdi.values
-                            .first()
-                    },
-                )
-
-            is VersjonertKontantstøtteSøknadV5 ->
-                Pair(
-                    versjonertSøknad.kontantstøtteSøknad.søker.ident.verdi.values
-                        .first(),
-                    versjonertSøknad.kontantstøtteSøknad.barn.map {
-                        it.ident.verdi.values
-                            .first()
-                    },
-                )
-        }
+    fun hentIdenterFraBarnetrygdSøknad(
+        journalpostId: String,
+    ): List<String> {
+        val søknad = baksVersjonertSøknadClient.hentVersjonertBarnetrygdSøknad(journalpostId)
+        return søknad.barnetrygdSøknad.personerISøknad()
     }
 
-    fun hentIdenterForBarnetrygdViaJournalpost(journalpostId: String): Pair<String, List<String>> {
-        val versjonertSøknad =
-            barnetrygdSøknadService
-                .hentDBSøknadFraJournalpost(journalpostId)
-                .hentVersjonertBarnetrygdSøknad()
-        return when (versjonertSøknad) {
-            is VersjonertBarnetrygdSøknadV8 ->
-                Pair(
-                    versjonertSøknad.barnetrygdSøknad.søker.ident.verdi.values
-                        .first(),
-                    versjonertSøknad.barnetrygdSøknad.barn.map {
-                        it.ident.verdi.values
-                            .first()
-                    },
-                )
-
-            is VersjonertBarnetrygdSøknadV9 ->
-                Pair(
-                    versjonertSøknad.barnetrygdSøknad.søker.ident.verdi.values
-                        .first(),
-                    versjonertSøknad.barnetrygdSøknad.barn.map {
-                        it.ident.verdi.values
-                            .first()
-                    },
-                )
-        }
+    fun hentIdenterFraKontantstøtteSøknad(
+        journalpostId: String,
+    ): List<String> {
+        val søknad = baksVersjonertSøknadClient.hentVersjonertKontantstøtteSøknad(journalpostId)
+        return søknad.kontantstøtteSøknad.personerISøknad()
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClientTest.kt
@@ -1,0 +1,127 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import no.nav.familie.baks.mottak.DevLauncher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.core.io.ClassPathResource
+import org.springframework.test.context.ActiveProfiles
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad as VersjonertBarnetrygdSøknadV9
+import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad as VersjonertKontantstøtteSøknadV5
+
+@SpringBootTest(classes = [DevLauncher::class], properties = ["FAMILIE_INTEGRASJONER_API_URL=http://localhost:28085/api"])
+@ActiveProfiles("dev", "mock-oauth")
+@AutoConfigureWireMock(port = 28085)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BaksVersjonertSøknadClientTest {
+    @Autowired
+    lateinit var baksVersjonertSøknadClient: BaksVersjonertSøknadClient
+
+    @Test
+    @Tag("integration")
+    fun `hentVersjonertBarnetrygdSøknad skal returnere VersjonertBarnetrygdSøknad OK og castes til sin tilhørende versjon`() {
+        // Arrange
+        val journalpostId = "123"
+        stubFor(
+            get(urlEqualTo("/api/baks/versjonertsoknad/ba/$journalpostId"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(hentResponsFraFil("versjonertBarnetrygdSøknadV9.json")),
+                ),
+        )
+
+        // Act
+        val versjonertBarnetrygdSøknad = baksVersjonertSøknadClient.hentVersjonertBarnetrygdSøknad(journalpostId)
+
+        // Assert
+        assertThat(versjonertBarnetrygdSøknad).isNotNull
+        assertThat(versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon).isEqualTo(9)
+        assertThat(versjonertBarnetrygdSøknad.barnetrygdSøknad).isInstanceOf(VersjonertBarnetrygdSøknadV9::class.java)
+
+        assertDoesNotThrow { versjonertBarnetrygdSøknad.barnetrygdSøknad as VersjonertBarnetrygdSøknadV9 }
+    }
+
+    @Test
+    @Tag("integration")
+    fun `hentVersjonertBarnetrygdSøknad skal kaste IntegrasjonException hvis respons er null`() {
+        val journalpostId = "123"
+        stubFor(
+            get(urlEqualTo("/api/baks/versjonertsoknad/ba/$journalpostId"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(hentResponsFraFil("feiletRespons.json")),
+                ),
+        )
+
+        val value = assertThrows<IntegrasjonException> { baksVersjonertSøknadClient.hentVersjonertBarnetrygdSøknad(journalpostId) }
+        assertThat(value.message).isEqualTo("Henting av søknad for barnetrygd feilet. journalpostId: $journalpostId")
+    }
+
+    @Test
+    @Tag("integration")
+    fun `hentVersjonertKontantStøtte skal returnere VersjonertKontantStøtte OK og castes til sin tilhørende versjon`() {
+        // Arrange
+        val journalpostId = "123"
+        stubFor(
+            get(urlEqualTo("/api/baks/versjonertsoknad/ks/$journalpostId"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(hentResponsFraFil("versjonertKontantstøtteSøknadV5.json")),
+                ),
+        )
+
+        // Act
+        val versjonertKontantStøtte = baksVersjonertSøknadClient.hentVersjonertKontantstøtteSøknad(journalpostId)
+
+        // Assert
+        assertThat(versjonertKontantStøtte).isNotNull
+        assertThat(versjonertKontantStøtte.kontantstøtteSøknad.kontraktVersjon).isEqualTo(5)
+        assertThat(versjonertKontantStøtte.kontantstøtteSøknad).isInstanceOf(VersjonertKontantstøtteSøknadV5::class.java)
+
+        assertDoesNotThrow { versjonertKontantStøtte.kontantstøtteSøknad as VersjonertKontantstøtteSøknadV5 }
+    }
+
+    @Test
+    @Tag("integration")
+    fun `hentVersjonertKontantStøtte skal kaste IntegrasjonException hvis respons er null`() {
+        val journalpostId = "123"
+        stubFor(
+            get(urlEqualTo("/api/baks/versjonertsoknad/ks/$journalpostId"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(hentResponsFraFil("feiletRespons.json")),
+                ),
+        )
+
+        val value = assertThrows<IntegrasjonException> { baksVersjonertSøknadClient.hentVersjonertKontantstøtteSøknad(journalpostId) }
+        assertThat(value.message).isEqualTo("Henting av søknad for kontantstøtte feilet. journalpostId: $journalpostId.")
+    }
+
+    @Throws(IOException::class)
+    private fun hentResponsFraFil(filnavn: String): String =
+        Files.readString(
+            ClassPathResource("testdata/$filnavn").file.toPath(),
+            StandardCharsets.UTF_8,
+        )
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AdressebeskyttelesesgraderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AdressebeskyttelesesgraderingServiceTest.kt
@@ -107,16 +107,16 @@ class AdressebeskyttelesesgraderingServiceTest {
             )
 
         every {
-            mockedSøknadsidenterService.hentIdenterForKontantstøtteViaJournalpost(
+            mockedSøknadsidenterService.hentIdenterFraKontantstøtteSøknad(
                 journalpostId = journalpost.journalpostId,
             )
-        } returns Pair("123456789", emptyList())
+        } returns listOf("123456789")
 
         every {
-            mockedSøknadsidenterService.hentIdenterForBarnetrygdViaJournalpost(
+            mockedSøknadsidenterService.hentIdenterFraBarnetrygdSøknad(
                 journalpostId = journalpost.journalpostId,
             )
-        } returns Pair("123456789", emptyList())
+        } returns listOf("123456789")
 
         every {
             mockedPdlClient.hentPerson(
@@ -222,16 +222,16 @@ class AdressebeskyttelesesgraderingServiceTest {
             )
 
         every {
-            mockedSøknadsidenterService.hentIdenterForKontantstøtteViaJournalpost(
+            mockedSøknadsidenterService.hentIdenterFraKontantstøtteSøknad(
                 journalpostId = journalpost.journalpostId,
             )
-        } returns Pair("123456789", emptyList())
+        } returns listOf("123456789")
 
         every {
-            mockedSøknadsidenterService.hentIdenterForBarnetrygdViaJournalpost(
+            mockedSøknadsidenterService.hentIdenterFraBarnetrygdSøknad(
                 journalpostId = journalpost.journalpostId,
             )
-        } returns Pair("123456789", emptyList())
+        } returns listOf("123456789")
 
         every {
             mockedPdlClient.hentPerson(

--- a/src/test/resources/testdata/feiletRespons.json
+++ b/src/test/resources/testdata/feiletRespons.json
@@ -1,0 +1,7 @@
+{
+  "data": {},
+  "status": "FEILET",
+  "melding": "Noe gikk galt",
+  "frontendFeilmelding": "Noe gikk galt",
+  "stacktrace": "Dette er en stacktrace"
+}

--- a/src/test/resources/testdata/versjonertBarnetrygdSøknadV9.json
+++ b/src/test/resources/testdata/versjonertBarnetrygdSøknadV9.json
@@ -1,0 +1,721 @@
+{
+  "data": {
+    "kontraktVersjon": 9,
+    "søker": {
+      "ident": {
+        "label": {
+          "en": "Ident",
+          "nb": "Ident",
+          "nn": "Ident"
+        },
+        "verdi": {
+          "nb": "12345678900",
+          "nn": "12345678900",
+          "en": "12345678900"
+        }
+      },
+      "harEøsSteg": false,
+      "navn": {
+        "label": {
+          "en": "Name",
+          "nb": "Navn",
+          "nn": "Namn"
+        },
+        "verdi": {
+          "nb": "SPETTETE GRØNNFINK",
+          "nn": "SPETTETE GRØNNFINK",
+          "en": "SPETTETE GRØNNFINK"
+        }
+      },
+      "statsborgerskap": {
+        "label": {
+          "en": "Citizenship",
+          "nb": "Statsborgerskap",
+          "nn": "Statsborgarskap"
+        },
+        "verdi": {
+          "nb": [
+            "Norge"
+          ],
+          "nn": [
+            "Noreg"
+          ],
+          "en": [
+            "Norway"
+          ]
+        }
+      },
+      "adresse": {
+        "label": {
+          "en": "Address",
+          "nb": "Adresse",
+          "nn": "Adresse"
+        },
+        "verdi": {
+          "nb": {
+            "adressenavn": "Testveien",
+            "postnummer": "0663",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "husnummer": "1",
+            "poststed": "OSLO"
+          },
+          "nn": {
+            "adressenavn": "Testveien",
+            "postnummer": "0663",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "husnummer": "1",
+            "poststed": "OSLO"
+          },
+          "en": {
+            "adressenavn": "Testveien",
+            "postnummer": "0663",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "husnummer": "1",
+            "poststed": "OSLO"
+          }
+        }
+      },
+      "adressebeskyttelse": false,
+      "sivilstand": {
+        "label": {
+          "en": "Marital status",
+          "nb": "Sivilstatus",
+          "nn": "Sivilstatus"
+        },
+        "verdi": {
+          "nb": "UGIFT",
+          "nn": "UGIFT",
+          "en": "UGIFT"
+        }
+      },
+      "spørsmål": {
+        "borPåRegistrertAdresse": {
+          "label": {
+            "en": "Do you live at this address?",
+            "nb": "Bor du på denne adressen?",
+            "nn": "Bur du på denne adressa?"
+          },
+          "verdi": {
+            "nb": "JA",
+            "nn": "JA",
+            "en": "JA"
+          }
+        },
+        "værtINorgeITolvMåneder": {
+          "label": {
+            "en": "Have you stayed continuously in Norway for the last twelve months?",
+            "nb": "Har du oppholdt deg sammenhengende i Norge de siste tolv månedene?",
+            "nn": "Har du opphalde deg samanhengande i Noreg dei siste tolv månadene?"
+          },
+          "verdi": {
+            "nb": "JA",
+            "nn": "JA",
+            "en": "JA"
+          }
+        },
+        "erAsylsøker": {
+          "label": {
+            "en": "Are you an asylum seeker?",
+            "nb": "Er du asylsøker?",
+            "nn": "Er du asylsøkar?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "arbeidIUtlandet": {
+          "label": {
+            "en": "Do you or have you worked outside of Norway, on a foreign ship or on another country's continental shelf?",
+            "nb": "Arbeider eller har du arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?",
+            "nn": "Arbeider eller har du arbeidt utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "mottarUtenlandspensjon": {
+          "label": {
+            "en": "Do you or have you received a pension from abroad?",
+            "nb": "Får eller har du fått pensjon fra utlandet?",
+            "nn": "Får eller har du fått pensjon frå utlandet?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        }
+      },
+      "nåværendeSamboer": null,
+      "tidligereSamboere": [],
+      "utenlandsperioder": [],
+      "andreUtbetalingsperioder": [],
+      "arbeidsperioderUtland": [],
+      "arbeidsperioderNorge": [],
+      "pensjonsperioderNorge": [],
+      "pensjonsperioderUtland": [],
+      "idNummer": []
+    },
+    "barn": [
+      {
+        "ident": {
+          "label": {
+            "en": "Ident",
+            "nb": "Ident",
+            "nn": "Ident"
+          },
+          "verdi": {
+            "nb": "12345678901",
+            "nn": "12345678901",
+            "en": "12345678901"
+          }
+        },
+        "harEøsSteg": false,
+        "navn": {
+          "label": {
+            "en": "Name",
+            "nb": "Navn",
+            "nn": "Namn"
+          },
+          "verdi": {
+            "nb": "Spettete Grønnfink",
+            "nn": "Spettete Grønnfink",
+            "en": "Spettete Grønnfink"
+          }
+        },
+        "registrertBostedType": {
+          "label": {
+            "en": "Registered place of residence",
+            "nb": "Registrert bosted",
+            "nn": "Registrert bustad"
+          },
+          "verdi": {
+            "nb": "IKKE_FYLT_INN",
+            "nn": "IKKE_FYLT_INN",
+            "en": "IKKE_FYLT_INN"
+          }
+        },
+        "alder": null,
+        "spørsmål": {
+          "erFosterbarn": {
+            "label": {
+              "en": "Which of the children are foster children?",
+              "nb": "Hvem av barna er fosterbarn?",
+              "nn": "Kven av barna er fosterbarn?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "erAdoptertFraUtland": {
+            "label": {
+              "en": "Which of the children are adopted from abroad?",
+              "nb": "Hvem av barna er adoptert fra utlandet?",
+              "nn": "Kven av barna er adoptert frå utlandet?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "erAsylsøker": {
+            "label": {
+              "en": "For which of the children has an application for asylum been submitted?",
+              "nb": "Hvem av barna er det søkt om asyl for?",
+              "nn": "Kven av barna er det søkt om asyl for?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "barnetrygdFraAnnetEøsland": {
+            "label": {
+              "en": "For which of the children are you receiving, have received or have applied for child benefit?",
+              "nb": "Hvem av barna får du, har du fått eller har du søkt om barnetrygd for?",
+              "nn": "Kven av barna får du, har du fått eller har du søkt om barnetrygd for?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "andreForelderErDød": {
+            "label": {
+              "en": "Which of the children is your previous spouse/cohabiting partner the parent of?",
+              "nb": "Hvem av barna er din tidligere ektefelle/samboer forelder til?",
+              "nn": "Kven av barna er din tidlegare ektefelle/sambuar forelder til?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "oppholderSegIInstitusjon": {
+            "label": {
+              "en": "Which of the children are in an institution?",
+              "nb": "Hvem av barna er i institusjon?",
+              "nn": "Kven av barna er seg i institusjon?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "institusjonIUtland": {
+            "label": {
+              "en": "The institution is outside of Norway",
+              "nb": "Institusjonen er i utlandet",
+              "nn": "Institusjonen er i utlandet"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "boddMindreEnn12MndINorge": {
+            "label": {
+              "en": "Which of the children have stayed outside of Norway during the last twelve months?",
+              "nb": "Hvem av barna har oppholdt seg utenfor Norge i løpet av de siste tolv månedene?",
+              "nn": "Kven av barna har oppheldt seg utanfor Noreg i løpet av dei siste tolv månadene?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "borFastMedSøker": {
+            "label": {
+              "en": "Does Spettete Grønnfink live with you on a permanent basis?",
+              "nb": "Bor Spettete Grønnfink fast sammen med deg?",
+              "nn": "Bur Spettete Grønnfink fast saman med deg?"
+            },
+            "verdi": {
+              "nb": "JA",
+              "nn": "JA",
+              "en": "JA"
+            }
+          },
+          "institusjonOppholdSluttdato": {
+            "label": {
+              "en": "When is the stay at the institution ending?",
+              "nb": "Når avsluttes institusjonsoppholdet?",
+              "nn": "Når avsluttast institusjonsopphaldet?"
+            },
+            "verdi": {
+              "nb": "",
+              "nn": "",
+              "en": ""
+            }
+          },
+          "adresse": {
+            "label": {
+              "en": "Where is Spettete Grønnfink's living during the period for which you are applying for child benefit?",
+              "nb": "Hvor bor Spettete Grønnfink i perioden det søkes om barnetrygd?",
+              "nn": "Kor bur Spettete Grønnfink i perioden det vert søkt om barnetrygd?"
+            },
+            "verdi": {
+              "nb": "",
+              "nn": "",
+              "en": ""
+            }
+          }
+        },
+        "utenlandsperioder": [],
+        "andreForelder": {
+          "kanIkkeGiOpplysninger": {
+            "label": {
+              "en": "I am unable to provide information about the other parent",
+              "nb": "Jeg kan ikke gi opplysninger om den andre forelderen",
+              "nn": "Eg kan ikkje gje opplysningar om den andre forelderen"
+            },
+            "verdi": {
+              "nb": "JA",
+              "nn": "JA",
+              "en": "JA"
+            }
+          },
+          "navn": null,
+          "fnr": null,
+          "fødselsdato": null,
+          "arbeidUtlandet": null,
+          "pensjonUtland": null,
+          "skriftligAvtaleOmDeltBosted": {
+            "label": {
+              "en": "Do you and the other parent have a written agreement on dual residence for Spettete Grønnfink?",
+              "nb": "Har du og den andre forelderen skriftlig avtale om delt bosted for Spettete Grønnfink?",
+              "nn": "Har du og den andre forelderen skriftleg avtale om delt bustad for Spettete Grønnfink?"
+            },
+            "verdi": {
+              "nb": "NEI",
+              "nn": "NEI",
+              "en": "NEI"
+            }
+          },
+          "pensjonNorge": null,
+          "arbeidNorge": null,
+          "andreUtbetalinger": null,
+          "idNummer": [],
+          "adresse": null,
+          "pågåendeSøknadFraAnnetEøsLand": null,
+          "pågåendeSøknadHvilketLand": null,
+          "barnetrygdFraEøs": null,
+          "arbeidsperioderUtland": [],
+          "pensjonsperioderUtland": [],
+          "arbeidsperioderNorge": [],
+          "pensjonsperioderNorge": [],
+          "andreUtbetalingsperioder": [],
+          "eøsBarnetrygdsperioder": [],
+          "utvidet": {
+            "søkerHarBoddMedAndreForelder": null,
+            "søkerFlyttetFraAndreForelderDato": null
+          }
+        },
+        "omsorgsperson": null,
+        "eøsBarnetrygdsperioder": [],
+        "idNummer": []
+      }
+    ],
+    "antallEøsSteg": 0,
+    "søknadstype": "ORDINÆR",
+    "finnesPersonMedAdressebeskyttelse": false,
+    "spørsmål": {
+      "erNoenAvBarnaFosterbarn": {
+        "label": {
+          "en": "Are any of the children foster children?",
+          "nb": "Er noen av barna fosterbarn?",
+          "nn": "Er nokre av barna fosterbarn?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "søktAsylForBarn": {
+        "label": {
+          "en": "Has an application for asylum been submitted for any of the children?",
+          "nb": "Er det søkt om asyl i Norge for noen av barna?",
+          "nn": "Er det søkt om asyl i Noreg for nokre av barna?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "oppholderBarnSegIInstitusjon": {
+        "label": {
+          "en": "Are any of the children in a child welfare institution or other institution?",
+          "nb": "Er noen av barna i barnverninstitusjon eller i annen institusjon?",
+          "nn": "Er nokre av barna i barneverninstitusjon eller i anna institusjon?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "barnOppholdtSegTolvMndSammenhengendeINorge": {
+        "label": {
+          "en": "Have the children stayed continuously in Norway during the last twelve months?",
+          "nb": "Har barna oppholdt seg sammenhengende i Norge de siste tolv månedene?",
+          "nn": "Har barna oppheldt seg samanhengande i Noreg dei siste tolv månadene?"
+        },
+        "verdi": {
+          "nb": "JA",
+          "nn": "JA",
+          "en": "JA"
+        }
+      },
+      "erBarnAdoptertFraUtland": {
+        "label": {
+          "en": "Are any of the children adopted from abroad?",
+          "nb": "Er noen av barna adoptert fra utlandet?",
+          "nn": "Er nokre av barna adoptert frå utlandet?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "mottarBarnetrygdForBarnFraAnnetEøsland": {
+        "label": {
+          "en": "Are you receiving, have you received or have you applied for child benefit for some of the children from another EEA country?",
+          "nb": "Får, har du fått eller har du søkt om barnetrygd for noen av barna fra et annet EØS land?",
+          "nn": "Får du, har du fått eller har du søkt om barnetrygd for nokre av barna frå eit anna EØS land?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "erAvdødPartnerForelder": {
+        "label": {
+          "en": "You are registered as a widow/widower in the Norwegian National Registry (folkeregisteret). Is your previous spouse the parent of any of the children you are applying for child benefit for?",
+          "nb": "Du er folkeregistrert som enke/enkemann. Er din tidligere ektefelle forelder til noen av barna du søker barnetrygd for?",
+          "nn": "Du er folkeregistrert som enke/enkemann. Er din tidlegare ektefelle forelder til nokre av barna du søker barnetrygd for?"
+        },
+        "verdi": {
+          "nb": null,
+          "nn": null,
+          "en": null
+        }
+      },
+      "lestOgForståttBekreftelse": {
+        "label": {
+          "en": "I am aware that I may lose my right to Child Benefit if I provide incorrect information. I am also aware that I will have to pay back any money I receive that I am not entitled to, that I have received if I have failed to provide information or have provided incorrect information.",
+          "nb": "Det er viktig at du gir oss riktige opplysninger slik at vi kan behandle saken din.",
+          "nn": "Det er viktig at du gir oss riktige opplysningar slik at me kan behandla saka di."
+        },
+        "verdi": {
+          "en": "I confirm that I will provide correct and complete information.",
+          "nb": "Jeg vil svare så godt jeg kan på spørsmålene i søknaden.",
+          "nn": "Eg svara så godt eg kan på spørsmåla i søknaden."
+        }
+      }
+    },
+    "dokumentasjon": [
+      {
+        "dokumentasjonsbehov": "BOR_FAST_MED_SØKER",
+        "harSendtInn": true,
+        "opplastedeVedlegg": [],
+        "dokumentasjonSpråkTittel": {
+          "en": "Confirmation that Spettete Grønnfink lives with you",
+          "nn": "Stadfesting på at Spettete Grønnfink bur med deg",
+          "nb": "Bekreftelse på at Spettete Grønnfink bor med deg"
+        }
+      },
+      {
+        "dokumentasjonsbehov": "ANNEN_DOKUMENTASJON",
+        "harSendtInn": false,
+        "opplastedeVedlegg": [],
+        "dokumentasjonSpråkTittel": {
+          "en": "Other documentation",
+          "nn": "Anna dokumentasjon",
+          "nb": "Annen dokumentasjon"
+        }
+      }
+    ],
+    "teksterUtenomSpørsmål": {
+      "hvilkebarn.barn.bosted.adressesperre": {
+        "en": "The child is registered with a blocked address.",
+        "nb": "Barnet er registrert med adressesperre.",
+        "nn": "Barnet er registrert med adressesperre."
+      },
+      "ombarnet.fosterbarn": {
+        "en": "You have stated that {navn} is a foster child",
+        "nb": "Du har opplyst at {navn} er fosterbarn",
+        "nn": "Du har opplyst at {navn} er fosterbarn"
+      },
+      "ombarnet.institusjon": {
+        "en": "You have stated that {navn} is in an institution",
+        "nb": "Du har opplyst at {navn} er i institusjon",
+        "nn": "Du har opplyst at {navn} er i institusjon"
+      },
+      "ombarnet.opplystatbarnutlandopphold.info": {
+        "en": "You have stated that {navn} has stayed outside of Norway during the last twelve months",
+        "nb": "Du har opplyst at {navn} har oppholdt seg utenfor Norge i løpet av de siste tolv månedene",
+        "nn": "Du har opplyst at {navn} har oppheldt seg utanfor Noreg i løpet av dei siste tolv månadene"
+      },
+      "ombarnet.barnetrygd-eøs": {
+        "en": "You have stated that you are receiving, have received or have applied for child benefit for {navn} from another EEA country.",
+        "nb": "Du har opplyst at du får, har fått eller har søkt om barnetrygd for {navn} fra et annet EØS land.",
+        "nn": "Du har opplyst at du får, har fått eller har søkt om barnetrygd for {navn} frå eit anna EØS land."
+      },
+      "omdeg.annensamboer.spm": {
+        "en": "Have you had a cohabiting partner earlier during the period for which you are applying for child benefit?",
+        "nb": "Har du hatt samboer tidligere i perioden du søker barnetrygd for?",
+        "nn": "Har du hatt sambuar tidlegare i perioden du søker barnetrygd for?"
+      },
+      "omdeg.personopplysninger.adressesperre.alert": {
+        "en": "You are registered with a blocked address",
+        "nb": "Du er registrert med adressesperre",
+        "nn": "Du er registrert med adressesperre"
+      },
+      "omdeg.personopplysninger.ikke-registrert.alert": {
+        "en": "You are not registered with a residential address in Norway",
+        "nb": "Du er ikke registrert med bostedsadresse i Norge",
+        "nn": "Du er ikkje registrert med bustadsadresse i Noreg"
+      },
+      "pdf.andreforelder.seksjonstittel": {
+        "en": "Child's other parent",
+        "nb": "Barnets andre forelder",
+        "nn": "Barnet sin andre forelder"
+      },
+      "pdf.hvilkebarn.seksjonstittel": {
+        "en": "Which children are you applying for?",
+        "nb": "Hvilke barn søker du for?",
+        "nn": "Kva barn søker du for?"
+      },
+      "pdf.hvilkebarn.registrert-på-adresse": {
+        "en": "Registered on applicant's address",
+        "nb": "Registrert på søkers adresse",
+        "nn": "Registrert på søkars adresse"
+      },
+      "pdf.hvilkebarn.ikke-registrert-på-adresse": {
+        "en": "Not registered on applicant's address",
+        "nb": "Ikke registrert på søkers adresse",
+        "nn": "Ikkje registrert på søkars adresse"
+      },
+      "pdf.ombarnet.seksjonstittel": {
+        "en": "About {navn}",
+        "nb": "Om {navn}",
+        "nn": "Om {navn}"
+      },
+      "pdf.omdeg.seksjonstittel": {
+        "en": "About you",
+        "nb": "Om deg",
+        "nn": "Om deg"
+      },
+      "pdf.bosted.seksjonstittel": {
+        "en": "Place of residence",
+        "nb": "Bosted",
+        "nn": "Bustad"
+      },
+      "pdf.ombarna.seksjonstittel": {
+        "en": "About your children",
+        "nb": "Om barna dine",
+        "nn": "Om barna dine"
+      },
+      "pdf.søker.seksjonstittel": {
+        "en": "Applicant",
+        "nb": "Søker",
+        "nn": "Søkar"
+      },
+      "pdf.vedlegg.seksjonstittel": {
+        "en": "List of attachments",
+        "nb": "Liste over vedlegg",
+        "nn": "Liste over vedlegg"
+      },
+      "pdf.vedlegg.lastet-opp-antall": {
+        "en": "Uploaded {antall} attachments",
+        "nb": "Lastet opp {antall} vedlegg",
+        "nn": "Lasta opp {antall} vedlegg"
+      },
+      "pdf.vedlegg.nummerering": {
+        "en": "Attachment {x} of {total}",
+        "nb": "Vedlegg {x} av {total}",
+        "nn": "Vedlegg {x} av {total}"
+      },
+      "dokumentasjon.har-sendt-inn.spm": {
+        "en": "I have already submitted this documentation to NAV in the past",
+        "nb": "Jeg har sendt inn denne dokumentasjonen til NAV tidligere",
+        "nn": "Eg har sendt inn denne dokumentasjonen til NAV tidlegare"
+      },
+      "dinlivssituasjon.sidetittel": {
+        "en": "Your life situation",
+        "nb": "Livssituasjonen din",
+        "nn": "Livssituasjonen din"
+      },
+      "pdf.dinlivssituasjon.tidligeresamboer.seksjonstittel": {
+        "en": "Former cohabitant {x}",
+        "nb": "Tidligere samboer {x}",
+        "nn": "Tidlegare sambuar {x}"
+      },
+      "eøs-om-deg.sidetittel": {
+        "en": "Child benefit by the EEA-regulations - About you",
+        "nb": "Barnetrygd etter EØS-reglene - Om deg",
+        "nn": "Barnetrygd etter EØS-reglane - Om deg"
+      },
+      "eøs-om-barn.sidetittel": {
+        "en": "Child benefit by the EEA-regulations - About {barn}",
+        "nb": "Barnetrygd etter EØS-reglene - Om {barn}",
+        "nn": "Barnetrygd etter EØS-reglane - Om {barn}"
+      },
+      "felles.sivilstatus.kode.GIFT": {
+        "en": "Married",
+        "nb": "Gift",
+        "nn": "Gift"
+      },
+      "felles.sivilstatus.kode.ENKE_ELLER_ENKEMANN": {
+        "en": "Widow(er)",
+        "nb": "Enke/Enkemann",
+        "nn": "Enke/enkemann"
+      },
+      "felles.sivilstatus.kode.SKILT": {
+        "en": "Divorced",
+        "nb": "Skilt",
+        "nn": "Skilt"
+      },
+      "felles.sivilstatus.kode.SEPARERT": {
+        "en": "Separated",
+        "nb": "Separert",
+        "nn": "Separert"
+      },
+      "felles.sivilstatus.kode.REGISTRERT_PARTNER": {
+        "en": "Registered partner",
+        "nb": "Registrert partner",
+        "nn": "Registrert partner"
+      },
+      "felles.sivilstatus.kode.SEPARERT_PARTNER": {
+        "en": "Separated partner",
+        "nb": "Separert partner",
+        "nn": "Separert partner"
+      },
+      "felles.sivilstatus.kode.SKILT_PARTNER": {
+        "en": "Divorced partner",
+        "nb": "Skilt partner",
+        "nn": "Skilt partner"
+      },
+      "felles.sivilstatus.kode.GJENLEVENDE_PARTNER": {
+        "en": "Surviving partner",
+        "nb": "Gjenlevende partner",
+        "nn": "Attlevande partner"
+      },
+      "felles.sivilstatus.kode.UGIFT": {
+        "en": "Unmarried",
+        "nb": "Ugift",
+        "nn": "Ugift"
+      },
+      "felles.sivilstatus.kode.UOPPGITT": {
+        "en": "Not specified",
+        "nb": "Ikke oppgitt",
+        "nn": "Ikkje oppgitt"
+      },
+      "felles.svaralternativ.ja": {
+        "en": "Yes",
+        "nb": "Ja",
+        "nn": "Ja"
+      },
+      "felles.svaralternativ.nei": {
+        "en": "No",
+        "nb": "Nei",
+        "nn": "Nei"
+      },
+      "felles.svaralternativ.vetikke": {
+        "en": "Don't know",
+        "nb": "Jeg vet ikke",
+        "nn": "Eg veit ikkje"
+      },
+      "skjermetAdresse": {
+        "en": "Blocked address",
+        "nn": "Skjerma adresse",
+        "nb": "Skjermet adresse"
+      }
+    },
+    "originalSpråk": "nb"
+  },
+  "status": "SUKSESS",
+  "melding": "OK",
+  "frontendFeilmelding": null,
+  "stacktrace": null
+}

--- a/src/test/resources/testdata/versjonertKontantstøtteSøknadV5.json
+++ b/src/test/resources/testdata/versjonertKontantstøtteSøknadV5.json
@@ -1,0 +1,949 @@
+{
+  "data": {
+    "kontraktVersjon": 5,
+    "søker": {
+      "harEøsSteg": false,
+      "ident": {
+        "label": {
+          "en": "Norwegian National identity number or D number",
+          "nn": "Fødselsnummer eller d-nummer",
+          "nb": "Fødselsnummer eller d-nummer"
+        },
+        "verdi": {
+          "nb": "12345678900",
+          "nn": "12345678900",
+          "en": "12345678900"
+        }
+      },
+      "navn": {
+        "label": {
+          "en": "Name",
+          "nn": "Namn",
+          "nb": "Navn"
+        },
+        "verdi": {
+          "nb": "KULTURELL HELDIGGRIS",
+          "nn": "KULTURELL HELDIGGRIS",
+          "en": "KULTURELL HELDIGGRIS"
+        }
+      },
+      "statsborgerskap": {
+        "label": {
+          "en": "Nationality",
+          "nn": "Statsborgarskap",
+          "nb": "Statsborgerskap"
+        },
+        "verdi": {
+          "nb": [
+            "Norge"
+          ],
+          "nn": [
+            "Noreg"
+          ],
+          "en": [
+            "Norway"
+          ]
+        }
+      },
+      "adresse": {
+        "label": {
+          "en": "Address",
+          "nn": "Adresse",
+          "nb": "Adresse"
+        },
+        "verdi": {
+          "nb": {
+            "adressenavn": "Testveien",
+            "postnummer": "5003",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "husnummer": "1",
+            "poststed": "OSLO"
+          },
+          "nn": {
+            "adressenavn": "Testveien",
+            "postnummer": "5003",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "husnummer": "1",
+            "poststed": "OSLO"
+          },
+          "en": {
+            "adressenavn": "Testveien",
+            "postnummer": "5003",
+            "husbokstav": null,
+            "bruksenhetsnummer": null,
+            "husnummer": "1",
+            "poststed": "OSLO"
+          }
+        }
+      },
+      "adressebeskyttelse": false,
+      "sivilstand": {
+        "label": {
+          "en": "Marital status",
+          "nn": "Sivilstatus",
+          "nb": "Sivilstatus"
+        },
+        "verdi": {
+          "nb": "UGIFT",
+          "nn": "UGIFT",
+          "en": "UGIFT"
+        }
+      },
+      "borPåRegistrertAdresse": {
+        "label": {
+          "en": "Do you live at this address?",
+          "nn": "Bur du på denne adressa?",
+          "nb": "Bor du på denne adressen?"
+        },
+        "verdi": {
+          "nb": "JA",
+          "nn": "JA",
+          "en": "JA"
+        }
+      },
+      "værtINorgeITolvMåneder": {
+        "label": {
+          "en": "Have you stayed continuously in Norway for the last twelve months?",
+          "nn": "Har du opphalde deg samanhengande i Noreg dei siste tolv månadane?",
+          "nb": "Har du oppholdt deg sammenhengende i Norge de siste tolv månedene?"
+        },
+        "verdi": {
+          "nb": "JA",
+          "nn": "JA",
+          "en": "JA"
+        }
+      },
+      "planleggerÅBoINorgeTolvMnd": {
+        "label": {
+          "en": "Are you planning to live in Norway continuously for more than 12 months?",
+          "nn": "Planlegg du å bu samanhengande i Noreg i meir enn tolv månader?",
+          "nb": "Planlegger du å bo sammenhengende i Norge i mer enn tolv måneder?"
+        },
+        "verdi": {
+          "nb": "JA",
+          "nn": "JA",
+          "en": "JA"
+        }
+      },
+      "yrkesaktivFemÅr": {
+        "label": {
+          "en": "Have you lived or been employed in Norway or another EEA country for at least five years?",
+          "nn": "Har du budd eller vore yrkesaktiv i Noreg eller eit anna EØS-land i minst fem år?",
+          "nb": "Har du bodd eller vært yrkesaktiv i Norge eller et annet EØS-land i minst fem år?"
+        },
+        "verdi": {
+          "nb": "JA",
+          "nn": "JA",
+          "en": "JA"
+        }
+      },
+      "erAsylsøker": {
+        "label": {
+          "en": "Are you an asylum seeker?",
+          "nn": "Er du asylsøkar?",
+          "nb": "Er du asylsøker?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "utenlandsoppholdUtenArbeid": {
+        "label": {
+          "en": "Are you staying or have you stayed outside of Norway without working?",
+          "nn": "Oppheld du deg, eller har du opphalde deg utanfor Noreg utan å arbeide?",
+          "nb": "Oppholder du deg, eller har du oppholdt deg, utenfor Norge uten å arbeide?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "utenlandsperioder": [],
+      "arbeidIUtlandet": {
+        "label": {
+          "en": "Do you work or have you worked outside of Norway, on a foreign ship or on another country's continental shelf?",
+          "nn": "Arbeider eller har du arbeidt utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?",
+          "nb": "Arbeider eller har du arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "arbeidsperioderUtland": [],
+      "mottarUtenlandspensjon": {
+        "label": {
+          "en": "Do you receive or have you received a pension from abroad?",
+          "nn": "Får eller har du fått pensjon frå utlandet?",
+          "nb": "Får eller har du fått pensjon fra utlandet?"
+        },
+        "verdi": {
+          "nb": "NEI",
+          "nn": "NEI",
+          "en": "NEI"
+        }
+      },
+      "pensjonsperioderUtland": [],
+      "arbeidINorge": null,
+      "arbeidsperioderNorge": [],
+      "pensjonNorge": null,
+      "pensjonsperioderNorge": [],
+      "andreUtbetalingsperioder": [],
+      "idNummer": [],
+      "andreUtbetalinger": null,
+      "adresseISøkeperiode": null
+    },
+    "barn": [
+      {
+        "harEøsSteg": false,
+        "ident": {
+          "label": {
+            "en": "Norwegian National identity number",
+            "nn": "Fødselsnummer",
+            "nb": "Fødselsnummer"
+          },
+          "verdi": {
+            "nb": "12345678901",
+            "nn": "12345678901",
+            "en": "12345678901"
+          }
+        },
+        "navn": {
+          "label": {
+            "en": "The child's name",
+            "nn": "Barnet sitt namn",
+            "nb": "Barnets navn"
+          },
+          "verdi": {
+            "nb": "TROVERDIG DETALJ",
+            "nn": "TROVERDIG DETALJ",
+            "en": "TROVERDIG DETALJ"
+          }
+        },
+        "registrertBostedType": {
+          "label": {
+            "en": "Registered place of residence",
+            "nn": "Registrert bustad",
+            "nb": "Registrert bosted"
+          },
+          "verdi": {
+            "nb": "REGISTRERT_SOKERS_ADRESSE",
+            "nn": "REGISTRERT_SOKERS_ADRESSE",
+            "en": "REGISTRERT_SOKERS_ADRESSE"
+          }
+        },
+        "alder": {
+          "label": {
+            "en": "Age",
+            "nn": "Alder",
+            "nb": "Alder"
+          },
+          "verdi": {
+            "nb": "1",
+            "nn": "1",
+            "en": "1"
+          }
+        },
+        "teksterTilPdf": {
+          "opplystAdoptert": {
+            "nn": "Du har opplyst at TROVERDIG DETALJ er adoptert.",
+            "nb": "Du har opplyst at TROVERDIG DETALJ er adoptert.",
+            "en": "You have stated that TROVERDIG DETALJ is adopted. "
+          },
+          "opplystBarnOppholdUtenforNorge": {
+            "nn": "Du har opplyst at TROVERDIG DETALJ har oppheldt seg utanfor Noreg i løpet av dei siste tolv månadene",
+            "nb": "Du har opplyst at TROVERDIG DETALJ har oppholdt seg utenfor Norge i løpet av de siste tolv månedene",
+            "en": "You have stated that TROVERDIG DETALJ has stayed outside of Norway during the last twelve months"
+          },
+          "opplystFaarHarFaattEllerSoektYtelse": {
+            "nn": "Du har opplyst at du får, har fått eller har søkt om kontantstøtte\nfor TROVERDIG DETALJ frå eit anna EØS-land.",
+            "nb": "Du har opplyst at du får, har fått eller har søkt om kontantstøtte\nfor TROVERDIG DETALJ fra et annet EØS-land.",
+            "en": "You have stated that you are receiving, have received or have applied for cash-for-care benefit for TROVERDIG DETALJ from another EEA country."
+          },
+          "opplystBarnehageplass": {
+            "nn": "Du har opplyst at TROVERDIG DETALJ har barnehageplass no, har hatt plass tidlegare, eller har blitt tildelt barnehageplass i framtida",
+            "nb": "Du har opplyst at TROVERDIG DETALJ har barnehageplass nå, har hatt plass tidligere, eller har fått tildelt en barnehageplass i framtiden",
+            "en": "You have stated that TROVERDIG DETALJ is attending kindergarten now, has previously attended kindergarten or will start attending kindergarten later"
+          },
+          "barnetsAndreForelder": {
+            "nn": "Barnet sin andre forelder",
+            "nb": "Barnets andre forelder",
+            "en": "The child's other parent"
+          },
+          "omBarnetTittel": {
+            "nn": "Om TROVERDIG DETALJ",
+            "nb": "Om TROVERDIG DETALJ",
+            "en": "About TROVERDIG DETALJ"
+          },
+          "bosted": {
+            "nn": "Bustad",
+            "nb": "Bosted",
+            "en": "Place of residence"
+          },
+          "eoesForBarnTittel": {
+            "nn": "kontantstøtte etter EØS-reglane - Om TROVERDIG DETALJ",
+            "nb": "kontantstøtte etter EØS-reglene - Om TROVERDIG DETALJ",
+            "en": "cash-for-care by the EEA-regulations - About TROVERDIG DETALJ"
+          }
+        },
+        "erFosterbarn": {
+          "label": {
+            "en": "Which of the children are foster children?",
+            "nn": "Kven av barna er fosterbarn?",
+            "nb": "Hvem av barna er fosterbarn?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "oppholderSegIInstitusjon": {
+          "label": {
+            "en": "Which of the children are in an institution?",
+            "nn": "Kven av barna er seg i institusjon?",
+            "nb": "Hvem av barna er i institusjon?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "erAdoptert": {
+          "label": {
+            "en": "Which of the children are adopted?",
+            "nn": "Kven av barna er adoptert?",
+            "nb": "Hvem av barna er adoptert?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "erAsylsøker": {
+          "label": {
+            "en": "For which of the children has an application for asylum been submitted?",
+            "nn": "Kven av barna er det søkt om asyl for?",
+            "nb": "Hvem av barna er det søkt om asyl for?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "boddMindreEnn12MndINorge": {
+          "label": {
+            "en": "Which of the children have stayed outside of Norway during the last twelve months?",
+            "nn": "Kven av barna har oppheldt seg utanfor Noreg i løpet av dei siste tolv månadene?",
+            "nb": "Hvem av barna har oppholdt seg utenfor Norge i løpet av de siste tolv månedene?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "kontantstøtteFraAnnetEøsland": {
+          "label": {
+            "en": "For which of the children are you receiving, have received or have applied for cash-for-care?",
+            "nn": "Kven av barna får du, har du fått eller har du søkt om kontantstøtte for?",
+            "nb": "Hvem av barna får du, har du fått eller har du søkt om kontantstøtte for?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "harBarnehageplass": {
+          "label": {
+            "en": "Which of the children are attending kindergarten now, have previously attended kindergarten or will start attending kindergarten later?",
+            "nn": "Kven av barna har barnehageplass no, har hatt plass tidlegare, eller har blitt tildelt barnehageplass i framtida",
+            "nb": "Hvem av barna har barnehageplass nå, har hatt plass tidligere, eller har fått tildelt en barnehageplass i framtiden?"
+          },
+          "verdi": {
+            "nb": "JA",
+            "nn": "JA",
+            "en": "JA"
+          }
+        },
+        "andreForelderErDød": {
+          "label": {
+            "en": "Which of the children is your previous spouse the parent of?",
+            "nn": "Kven av barna er din tidlegare ektefelle forelder til?",
+            "nb": "Hvem av barna er din tidligere ektefelle forelder til?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "utbetaltForeldrepengerEllerEngangsstønad": null,
+        "mottarEllerMottokEøsKontantstøtte": null,
+        "pågåendeSøknadFraAnnetEøsLand": null,
+        "pågåendeSøknadHvilketLand": null,
+        "planleggerÅBoINorge12Mnd": null,
+        "eøsKontantstøttePerioder": [],
+        "barnehageplassPerioder": [
+          {
+            "label": {
+              "en": "Period of attending kindergarten 1",
+              "nn": "Periode med barnehageplass 1",
+              "nb": "Periode med barnehageplass 1"
+            },
+            "verdi": {
+              "nb": {
+                "barnehageplassPeriodeBeskrivelse": {
+                  "label": {
+                    "en": "What best describes the period the child has attended kindergarten?",
+                    "nn": "Kva beskriv perioden barnet har hatt barnehageplass best?",
+                    "nb": "Hva beskriver perioden barnet har hatt barnehageplass best?"
+                  },
+                  "verdi": {
+                    "en": "The child will start attending kindergarten later",
+                    "nn": "Barnet har fått tildelt barnehageplass med oppstart seinare",
+                    "nb": "Barnet har fått tildelt barnehageplass med oppstart senere"
+                  }
+                },
+                "barnehageplassUtlandet": {
+                  "label": {
+                    "en": "Is the kindergarten outside of Norway?",
+                    "nn": "Er barnehagen utanfor Noreg?",
+                    "nb": "Er barnehagen utenfor Norge?"
+                  },
+                  "verdi": {
+                    "nb": "NEI",
+                    "nn": "NEI",
+                    "en": "NEI"
+                  }
+                },
+                "barnehageplassLand": null,
+                "offentligStøtte": null,
+                "antallTimer": {
+                  "label": {
+                    "en": "How many hours per week has the child been allotted to attend the kindergarten?",
+                    "nn": "Kor mange timar i uka har barnet fått tildelt barnehageplass?",
+                    "nb": "Hvor mange timer i uken har barnet fått tildelt barnehageplass?"
+                  },
+                  "verdi": {
+                    "nb": "40",
+                    "nn": "40",
+                    "en": "40"
+                  }
+                },
+                "startetIBarnehagen": {
+                  "label": {
+                    "en": "When will the child start attending kindergarten?",
+                    "nn": "Når har barnet fått tildelt barnehageplass frå?",
+                    "nb": "Når har barnet fått tildelt barnehageplass fra?"
+                  },
+                  "verdi": {
+                    "nb": "2025-02-17",
+                    "nn": "2025-02-17",
+                    "en": "2025-02-17"
+                  }
+                },
+                "slutterIBarnehagen": {
+                  "label": {
+                    "en": "When will the child stop attending kindergarten?",
+                    "nn": "Når sluttar barnet i barnehagen?",
+                    "nb": "Når slutter barnet i barnehagen?"
+                  },
+                  "verdi": {
+                    "en": "It is not agreed when the child will stop attending kindergarten",
+                    "nn": "Det er ikkje avtalt når barnet skal slutte i barnehagen",
+                    "nb": "Det er ikke avtalt når barnet skal slutte i barnehagen"
+                  }
+                }
+              },
+              "nn": {
+                "barnehageplassPeriodeBeskrivelse": {
+                  "label": {
+                    "en": "What best describes the period the child has attended kindergarten?",
+                    "nn": "Kva beskriv perioden barnet har hatt barnehageplass best?",
+                    "nb": "Hva beskriver perioden barnet har hatt barnehageplass best?"
+                  },
+                  "verdi": {
+                    "en": "The child will start attending kindergarten later",
+                    "nn": "Barnet har fått tildelt barnehageplass med oppstart seinare",
+                    "nb": "Barnet har fått tildelt barnehageplass med oppstart senere"
+                  }
+                },
+                "barnehageplassUtlandet": {
+                  "label": {
+                    "en": "Is the kindergarten outside of Norway?",
+                    "nn": "Er barnehagen utanfor Noreg?",
+                    "nb": "Er barnehagen utenfor Norge?"
+                  },
+                  "verdi": {
+                    "nb": "NEI",
+                    "nn": "NEI",
+                    "en": "NEI"
+                  }
+                },
+                "barnehageplassLand": null,
+                "offentligStøtte": null,
+                "antallTimer": {
+                  "label": {
+                    "en": "How many hours per week has the child been allotted to attend the kindergarten?",
+                    "nn": "Kor mange timar i uka har barnet fått tildelt barnehageplass?",
+                    "nb": "Hvor mange timer i uken har barnet fått tildelt barnehageplass?"
+                  },
+                  "verdi": {
+                    "nb": "40",
+                    "nn": "40",
+                    "en": "40"
+                  }
+                },
+                "startetIBarnehagen": {
+                  "label": {
+                    "en": "When will the child start attending kindergarten?",
+                    "nn": "Når har barnet fått tildelt barnehageplass frå?",
+                    "nb": "Når har barnet fått tildelt barnehageplass fra?"
+                  },
+                  "verdi": {
+                    "nb": "2025-02-17",
+                    "nn": "2025-02-17",
+                    "en": "2025-02-17"
+                  }
+                },
+                "slutterIBarnehagen": {
+                  "label": {
+                    "en": "When will the child stop attending kindergarten?",
+                    "nn": "Når sluttar barnet i barnehagen?",
+                    "nb": "Når slutter barnet i barnehagen?"
+                  },
+                  "verdi": {
+                    "en": "It is not agreed when the child will stop attending kindergarten",
+                    "nn": "Det er ikkje avtalt når barnet skal slutte i barnehagen",
+                    "nb": "Det er ikke avtalt når barnet skal slutte i barnehagen"
+                  }
+                }
+              },
+              "en": {
+                "barnehageplassPeriodeBeskrivelse": {
+                  "label": {
+                    "en": "What best describes the period the child has attended kindergarten?",
+                    "nn": "Kva beskriv perioden barnet har hatt barnehageplass best?",
+                    "nb": "Hva beskriver perioden barnet har hatt barnehageplass best?"
+                  },
+                  "verdi": {
+                    "en": "The child will start attending kindergarten later",
+                    "nn": "Barnet har fått tildelt barnehageplass med oppstart seinare",
+                    "nb": "Barnet har fått tildelt barnehageplass med oppstart senere"
+                  }
+                },
+                "barnehageplassUtlandet": {
+                  "label": {
+                    "en": "Is the kindergarten outside of Norway?",
+                    "nn": "Er barnehagen utanfor Noreg?",
+                    "nb": "Er barnehagen utenfor Norge?"
+                  },
+                  "verdi": {
+                    "nb": "NEI",
+                    "nn": "NEI",
+                    "en": "NEI"
+                  }
+                },
+                "barnehageplassLand": null,
+                "offentligStøtte": null,
+                "antallTimer": {
+                  "label": {
+                    "en": "How many hours per week has the child been allotted to attend the kindergarten?",
+                    "nn": "Kor mange timar i uka har barnet fått tildelt barnehageplass?",
+                    "nb": "Hvor mange timer i uken har barnet fått tildelt barnehageplass?"
+                  },
+                  "verdi": {
+                    "nb": "40",
+                    "nn": "40",
+                    "en": "40"
+                  }
+                },
+                "startetIBarnehagen": {
+                  "label": {
+                    "en": "When will the child start attending kindergarten?",
+                    "nn": "Når har barnet fått tildelt barnehageplass frå?",
+                    "nb": "Når har barnet fått tildelt barnehageplass fra?"
+                  },
+                  "verdi": {
+                    "nb": "2025-02-17",
+                    "nn": "2025-02-17",
+                    "en": "2025-02-17"
+                  }
+                },
+                "slutterIBarnehagen": {
+                  "label": {
+                    "en": "When will the child stop attending kindergarten?",
+                    "nn": "Når sluttar barnet i barnehagen?",
+                    "nb": "Når slutter barnet i barnehagen?"
+                  },
+                  "verdi": {
+                    "en": "It is not agreed when the child will stop attending kindergarten",
+                    "nn": "Det er ikkje avtalt når barnet skal slutte i barnehagen",
+                    "nb": "Det er ikke avtalt når barnet skal slutte i barnehagen"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "borFastMedSøker": {
+          "label": {
+            "en": "Does TROVERDIG DETALJ live with you on a permanent basis?",
+            "nn": "Bur TROVERDIG DETALJ fast saman med deg?",
+            "nb": "Bor TROVERDIG DETALJ fast sammen med deg?"
+          },
+          "verdi": {
+            "nb": "JA",
+            "nn": "JA",
+            "en": "JA"
+          }
+        },
+        "foreldreBorSammen": {
+          "label": {
+            "en": "Do you live with TROVERDIG DETALJ's other parent?",
+            "nn": "Bur du saman med den andre forelderen til TROVERDIG DETALJ?",
+            "nb": "Bor du sammen med den andre forelderen til TROVERDIG DETALJ?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "søkerDeltKontantstøtte": {
+          "label": {
+            "en": "Do you want to apply for a splitted cash-for-care benefit?",
+            "nn": "Søker du om delt kontantstøtte for TROVERDIG DETALJ?",
+            "nb": "Søker du om delt kontantstøtte for TROVERDIG DETALJ?"
+          },
+          "verdi": {
+            "nb": "NEI",
+            "nn": "NEI",
+            "en": "NEI"
+          }
+        },
+        "andreForelder": {
+          "kanIkkeGiOpplysninger": {
+            "label": {
+              "en": "I am unable to provide information about the other parent",
+              "nn": "Eg kan ikkje gje opplysningar om den andre forelderen",
+              "nb": "Jeg kan ikke gi opplysninger om den andre forelderen"
+            },
+            "verdi": {
+              "nb": "JA",
+              "nn": "JA",
+              "en": "JA"
+            }
+          },
+          "navn": null,
+          "fnr": null,
+          "fødselsdato": null,
+          "yrkesaktivFemÅr": null,
+          "arbeidUtlandet": null,
+          "arbeidsperioderUtland": [],
+          "utenlandsoppholdUtenArbeid": null,
+          "utenlandsperioder": [],
+          "pensjonUtland": null,
+          "pensjonsperioderUtland": [],
+          "idNummer": [],
+          "adresse": null,
+          "arbeidNorge": null,
+          "arbeidsperioderNorge": [],
+          "pensjonNorge": null,
+          "pensjonsperioderNorge": [],
+          "andreUtbetalinger": null,
+          "andreUtbetalingsperioder": [],
+          "pågåendeSøknadFraAnnetEøsLand": null,
+          "pågåendeSøknadHvilketLand": null,
+          "kontantstøtteFraEøs": null,
+          "eøsKontantstøttePerioder": []
+        },
+        "utenlandsperioder": [],
+        "søkersSlektsforhold": null,
+        "søkersSlektsforholdSpesifisering": null,
+        "borMedAndreForelder": null,
+        "borMedOmsorgsperson": null,
+        "adresse": null,
+        "omsorgsperson": null,
+        "idNummer": []
+      }
+    ],
+    "antallEøsSteg": 0,
+    "dokumentasjon": [
+      {
+        "dokumentasjonsbehov": "BEKREFTELESE_PÅ_BARNEHAGEPLASS",
+        "harSendtInn": false,
+        "opplastedeVedlegg": [],
+        "dokumentasjonSpråkTittel": {
+          "nn": "Stadfesting på barnehageplass",
+          "nb": "Bekreftelse på barnehageplass",
+          "en": "Confirmation of allocated kindergarten (place in kindergarten)"
+        }
+      },
+      {
+        "dokumentasjonsbehov": "ANNEN_DOKUMENTASJON",
+        "harSendtInn": false,
+        "opplastedeVedlegg": [],
+        "dokumentasjonSpråkTittel": {
+          "nn": "Anna dokumentasjon",
+          "nb": "Annen dokumentasjon",
+          "en": "Other documentation"
+        }
+      }
+    ],
+    "teksterTilPdf": {
+      "sivilstandGift": {
+        "nn": "Gift",
+        "nb": "Gift",
+        "en": "Married"
+      },
+      "sivilstandEnkeEnkemann": {
+        "nn": "Enke/enkemann",
+        "nb": "Enke/enkemann",
+        "en": "Widow(er)"
+      },
+      "sivilstandSkilt": {
+        "nn": "Skilt",
+        "nb": "Skilt",
+        "en": "Divorced"
+      },
+      "sivilstandSeparert": {
+        "nn": "Separert",
+        "nb": "Separert",
+        "en": "Separated"
+      },
+      "sivilstandRegistrertPartner": {
+        "nn": "Registrert partner",
+        "nb": "Registrert partner",
+        "en": "Registered partner"
+      },
+      "sivilstandSeparertPartner": {
+        "nn": "Separert partner",
+        "nb": "Separert partner",
+        "en": "Separated partner"
+      },
+      "sivilstandSkiltPartner": {
+        "nn": "Skilt partner",
+        "nb": "Skilt partner",
+        "en": "Divorced partner"
+      },
+      "sivilstandGjenlevendePartner": {
+        "nn": "Attlevande partner",
+        "nb": "Gjenlevende partner",
+        "en": "Surviving partner"
+      },
+      "sivilstandUgift": {
+        "nn": "Ugift",
+        "nb": "Ugift",
+        "en": "Unmarried"
+      },
+      "sivilstandUoppgitt": {
+        "nn": "Ikkje oppgitt",
+        "nb": "Ikke oppgitt",
+        "en": "Not specified"
+      },
+      "bekreftelsesboksBroedtekst": {
+        "nn": "Det er viktig at du gir oss riktige opplysningar slik at vi kan behandla saka di. Les meir om viktigheita av å gi riktige opplysningar (blir opna i nytt vindauge).",
+        "nb": "Det er viktig at du gir oss riktige opplysninger slik at vi kan behandle saken din. Les mer om viktigheten av å gi riktige opplysninger (åpnes i nytt vindu).",
+        "en": "It’s important that you give us accurate information so we can handle your case correctly. You can read more about why providing the right information matters (opens in a new window)."
+      },
+      "bekreftelsesboksErklaering": {
+        "nn": "Eg stadfestar at eg vil svara så godt eg kan på spørsmåla i søknaden.",
+        "nb": "Jeg vil svare så godt jeg kan på spørsmålene i søknaden.",
+        "en": "I will do my best to answer all the questions in the application truthfully."
+      },
+      "soekerAdressesperre": {
+        "nn": "Du er registrert med adressesperre",
+        "nb": "Du er registrert med adressesperre",
+        "en": "You are registered with a blocked address"
+      },
+      "ikkeRegistrertAdresse": {
+        "nn": "Du er ikkje registrert med bustadsadresse i Noreg",
+        "nb": "Du er ikke registrert med bostedsadresse i Norge",
+        "en": "You are not registered with a residential address in Norway"
+      },
+      "skjermetAdresse": {
+        "nn": "Skjerma adresse",
+        "nb": "Skjermet adresse",
+        "en": "Blocked address"
+      },
+      "omDegTittel": {
+        "nn": "Om deg",
+        "nb": "Om deg",
+        "en": "About you"
+      },
+      "dinLivssituasjonTittel": {
+        "nn": "Livssituasjonen din",
+        "nb": "Livssituasjonen din",
+        "en": "Your life situation"
+      },
+      "registrertMedAdressesperre": {
+        "nn": "Barnet er registrert med adressesperre.",
+        "nb": "Barnet er registrert med adressesperre.",
+        "en": "The child is registered with a blocked address."
+      },
+      "velgBarnTittel": {
+        "nn": "Kva barn søker du for?",
+        "nb": "Hvilke barn søker du for?",
+        "en": "Which children are you applying for benefit for?"
+      },
+      "registrertPaaAdressenDin": {
+        "nn": "Registrert på adressa di",
+        "nb": "Registrert på adressen din",
+        "en": "Registered as living at your address"
+      },
+      "ikkeRegistrertPaaAdressenDin": {
+        "nn": "Ikkje registrert på adressa di",
+        "nb": "Ikke registrert på adressen din",
+        "en": "Not registered as living at your address"
+      },
+      "omBarnaTittel": {
+        "nn": "Om barna dine",
+        "nb": "Om barna dine",
+        "en": "About your children"
+      },
+      "eoesForSoekerTittel": {
+        "nn": "kontantstøtte etter EØS-reglane - Om deg",
+        "nb": "kontantstøtte etter EØS-reglene - Om deg",
+        "en": "cash-for-care by the EEA-regulations - About you"
+      },
+      "vedlegg": {
+        "nn": "Vedlegg",
+        "nb": "Vedlegg",
+        "en": "Attachment"
+      },
+      "av": {
+        "nn": "av",
+        "nb": "av",
+        "en": "of"
+      },
+      "soeker": {
+        "nn": "Søkar",
+        "nb": "Søker",
+        "en": "Applicant"
+      },
+      "sendtInnTidligere": {
+        "nn": "Eg har sendt inn denne dokumentasjonen til NAV tidlegare",
+        "nb": "Jeg har sendt inn denne dokumentasjonen til NAV tidligere",
+        "en": "I have already submitted this documentation to NAV in the past"
+      },
+      "ja": {
+        "nn": "Ja",
+        "nb": "Ja",
+        "en": "Yes"
+      },
+      "nei": {
+        "nn": "Nei",
+        "nb": "Nei",
+        "en": "No"
+      },
+      "jegVetIkke": {
+        "nn": "Eg veit ikkje",
+        "nb": "Jeg vet ikke",
+        "en": "I don't know"
+      }
+    },
+    "originalSpråk": "nb",
+    "finnesPersonMedAdressebeskyttelse": false,
+    "erNoenAvBarnaFosterbarn": {
+      "label": {
+        "en": "Are any of the children foster children?",
+        "nn": "Er nokre av barna fosterbarn?",
+        "nb": "Er noen av barna fosterbarn?"
+      },
+      "verdi": {
+        "nb": "NEI",
+        "nn": "NEI",
+        "en": "NEI"
+      }
+    },
+    "søktAsylForBarn": {
+      "label": {
+        "en": "Has an application for asylum been submitted for any of the children?",
+        "nn": "Er det søkt om asyl i Noreg for nokre av barna?",
+        "nb": "Er det søkt om asyl i Norge for noen av barna?"
+      },
+      "verdi": {
+        "nb": "NEI",
+        "nn": "NEI",
+        "en": "NEI"
+      }
+    },
+    "oppholderBarnSegIInstitusjon": {
+      "label": {
+        "en": "Are any of the children in a child welfare institution?",
+        "nn": "Er nokre av barna i barneverninstitusjon?",
+        "nb": "Er noen av barna i barnverninstitusjon?"
+      },
+      "verdi": {
+        "nb": "NEI",
+        "nn": "NEI",
+        "en": "NEI"
+      }
+    },
+    "barnOppholdtSegTolvMndSammenhengendeINorge": {
+      "label": {
+        "en": "Have the children stayed continuously in Norway during the last twelve months?",
+        "nn": "Har barna oppheldt seg samanhengande i Noreg dei siste tolv månadane?",
+        "nb": "Har barna oppholdt seg sammenhengende i Norge de siste tolv månedene?"
+      },
+      "verdi": {
+        "nb": "JA",
+        "nn": "JA",
+        "en": "JA"
+      }
+    },
+    "erBarnAdoptert": {
+      "label": {
+        "en": "Are any of the children adopted?",
+        "nn": "Er nokre av barna adoptert?",
+        "nb": "Er noen av barna adoptert?"
+      },
+      "verdi": {
+        "nb": "NEI",
+        "nn": "NEI",
+        "en": "NEI"
+      }
+    },
+    "mottarKontantstøtteForBarnFraAnnetEøsland": {
+      "label": {
+        "en": "Are you receiving, have you received or have you applied for cash-for-care for some of the children from another EEA country?",
+        "nn": "Får du, har du fått eller har du søkt om kontantstøtte for nokre av barna frå eit anna EØS-land?",
+        "nb": "Får du, har du fått eller har du søkt om kontantstøtte for noen av barna fra et annet EØS-land?"
+      },
+      "verdi": {
+        "nb": "NEI",
+        "nn": "NEI",
+        "en": "NEI"
+      }
+    },
+    "harEllerTildeltBarnehageplass": {
+      "label": {
+        "en": "Are any of the children attending kindergarten now, have they previously attended kindergarten or will they start attending kindergarten later?",
+        "nn": "Har nokre av barna barnehageplass no, har dei hatt plass tidlegare, eller har dei blitt tildelt barnehageplass i framtida",
+        "nb": "Har noen av barna barnehageplass nå, har de hatt plass tidligere, eller har de fått tildelt en barnehageplass i framtiden?"
+      },
+      "verdi": {
+        "nb": "JA",
+        "nn": "JA",
+        "en": "JA"
+      }
+    },
+    "erAvdødPartnerForelder": null
+  },
+  "status": "SUKSESS",
+  "melding": "OK",
+  "frontendFeilmelding": null,
+  "stacktrace": null
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23434.

Oppretter klient for å hente ut VersjonertSøknad fra familie-integrasjoner, som er en del av en innsats på å skrive oss vekk fra Søknad DB. I første omgang fases ut henting av identer.

Testet søknadsløype OK i preprod. Litt bekymret for om endringene i kontrakter kan ha en slagside, men finner ikke noe rusk siden jeg ikke har funnet noe sted hvor det har vært noe behov for å serialisere en søknad hittil.