### PR TITLE
NAV-24505: Setter behandlingstema og behandlingstype for klage i KS og BA oppgave mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>2.20250219093533_62416e5</prosessering.version>
 
         <felles.version>3.20250220215513_776c72f</felles.version>
-        <kontrakter.version>3.0_20250211100920_f88b1ab</kontrakter.version>
+        <kontrakter.version>3.0_20250304150422_c587a15</kontrakter.version>
 
         <main-class>no.nav.familie.baks.mottak.LauncherKt</main-class>
         <spring.cloud.version>4.2.0</spring.cloud.version>

--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
@@ -8,5 +8,6 @@ class FeatureToggleConfig {
         // Release
         const val AUTOMATISK_JOURNALFØRING_AV_KONTANTSTØTTE_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ks-soknad"
         const val AUTOMATISK_JOURNALFØRING_AV_BARNETRYGD_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ba-soknad"
+        const val SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE = "familie-baks-mottak.sett-behandlingstema-og-behandlingstype-for-klage";
     }
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
@@ -8,6 +8,6 @@ class FeatureToggleConfig {
         // Release
         const val AUTOMATISK_JOURNALFØRING_AV_KONTANTSTØTTE_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ks-soknad"
         const val AUTOMATISK_JOURNALFØRING_AV_BARNETRYGD_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ba-soknad"
-        const val SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE = "familie-baks-mottak.sett-behandlingstema-og-behandlingstype-for-klage";
+        const val SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE = "familie-baks-mottak.sett-behandlingstema-og-behandlingstype-for-klage"
     }
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -17,9 +17,9 @@ class BarnetrygdOppgaveMapper(
     val søknadRepository: SøknadRepository,
     private val unleashService: UnleashNextMedContextService,
 ) : AbstractOppgaveMapper(
-    enhetsnummerService = enhetsnummerService,
-    pdlClient = pdlClient,
-) {
+        enhetsnummerService = enhetsnummerService,
+        pdlClient = pdlClient,
+    ) {
     override val tema: Tema = Tema.BAR
 
     // Behandlingstema og behandlingstype settes basert på regelsettet som er dokumentert nederst her: https://confluence.adeo.no/display/TFA/Mottak+av+dokumenter

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.harEøsSteg
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -13,10 +15,11 @@ class BarnetrygdOppgaveMapper(
     enhetsnummerService: EnhetsnummerService,
     pdlClient: PdlClient,
     val søknadRepository: SøknadRepository,
+    private val unleashService: UnleashNextMedContextService,
 ) : AbstractOppgaveMapper(
-        enhetsnummerService = enhetsnummerService,
-        pdlClient = pdlClient,
-    ) {
+    enhetsnummerService = enhetsnummerService,
+    pdlClient = pdlClient,
+) {
     override val tema: Tema = Tema.BAR
 
     // Behandlingstema og behandlingstype settes basert på regelsettet som er dokumentert nederst her: https://confluence.adeo.no/display/TFA/Mottak+av+dokumenter
@@ -31,6 +34,7 @@ class BarnetrygdOppgaveMapper(
 
             erDnummerPåJournalpost(journalpost) -> Behandlingstema.BarnetrygdEØS
             hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> null
+            journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> null
             else -> Behandlingstema.OrdinærBarnetrygd
         }
 
@@ -46,6 +50,7 @@ class BarnetrygdOppgaveMapper(
                 }
 
             hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> Behandlingstype.Utland
+            journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> Behandlingstype.Klage
             else -> null
         }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.harEøsSteg
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -13,10 +15,11 @@ class KontantstøtteOppgaveMapper(
     enhetsnummerService: EnhetsnummerService,
     pdlClient: PdlClient,
     val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
+    private val unleashService: UnleashNextMedContextService,
 ) : AbstractOppgaveMapper(
-        enhetsnummerService = enhetsnummerService,
-        pdlClient = pdlClient,
-    ) {
+    enhetsnummerService = enhetsnummerService,
+    pdlClient = pdlClient,
+) {
     override val tema: Tema = Tema.KON
 
     override fun hentBehandlingstema(journalpost: Journalpost): Behandlingstema? = null
@@ -35,6 +38,7 @@ class KontantstøtteOppgaveMapper(
                 }
 
             erDnummerPåJournalpost(journalpost) -> Behandlingstype.EØS
+            journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> Behandlingstype.Klage
             else -> Behandlingstype.NASJONAL
         }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -17,9 +17,9 @@ class KontantstøtteOppgaveMapper(
     val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
     private val unleashService: UnleashNextMedContextService,
 ) : AbstractOppgaveMapper(
-    enhetsnummerService = enhetsnummerService,
-    pdlClient = pdlClient,
-) {
+        enhetsnummerService = enhetsnummerService,
+        pdlClient = pdlClient,
+    ) {
     override val tema: Tema = Tema.KON
 
     override fun hentBehandlingstema(journalpost: Journalpost): Behandlingstema? = null

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
@@ -1,0 +1,207 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.søknad.SøknadTestData
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class BarnetrygdOppgaveMapperTest {
+
+    private val enhetsnummerService: EnhetsnummerService = mockk()
+    private val pdlClient: PdlClient = mockk()
+    private val søknadRepository: SøknadRepository = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
+
+    private val barnetrygdOppgaveMapper = BarnetrygdOppgaveMapper(
+        enhetsnummerService = enhetsnummerService,
+        pdlClient = pdlClient,
+        søknadRepository = søknadRepository,
+        unleashService = unleashService
+    )
+
+    @BeforeEach
+    fun oppsett() {
+        every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns true
+    }
+
+    @Nested
+    inner class HentBehandlingstema {
+        @Test
+        fun `skal returnere ordinær barnetrygd hvis man har dokumenter for både barnetrygd søknad og klage, og er digital`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "132",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
+
+            // Assert
+            assertThat(behandlingstema).isEqualTo(Behandlingstema.OrdinærBarnetrygd)
+        }
+
+        @Test
+        fun `skal returnere null for klage`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
+
+            // Assert
+            assertThat(behandlingstema).isNull()
+        }
+
+        @Test
+        fun `skal returnere ordinær barnetrygd for klage hvis toggle er skrudd av`() {
+            // Arrange
+            every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns false
+
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
+
+            // Assert
+            assertThat(behandlingstema).isEqualTo(Behandlingstema.OrdinærBarnetrygd)
+        }
+    }
+
+    @Nested
+    inner class HentBehandlingstype {
+        @Test
+        fun `skal returnere EØS hvis man har dokumenter for både barnetrygd EØS søknad og klage, og er digital`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "132",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            every { søknadRepository.getByJournalpostId(journalpost.journalpostId) } returns DBBarnetrygdSøknad(
+                id = 0,
+                objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
+                "12345678093",
+                LocalDateTime.now(),
+            )
+
+            // Act
+            val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isEqualTo(Behandlingstype.EØS)
+        }
+
+        @Test
+        fun `skal returnere behandlingstype klage hvis man har dokumenter for klage`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isEqualTo(Behandlingstype.Klage)
+        }
+
+        @Test
+        fun `skal returnere behandlingstype null hvis man har dokumenter for klage men toggle er skrudd av`() {
+            // Arrange
+            every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns false
+
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
@@ -22,18 +22,18 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class BarnetrygdOppgaveMapperTest {
-
     private val enhetsnummerService: EnhetsnummerService = mockk()
     private val pdlClient: PdlClient = mockk()
     private val søknadRepository: SøknadRepository = mockk()
     private val unleashService: UnleashNextMedContextService = mockk()
 
-    private val barnetrygdOppgaveMapper = BarnetrygdOppgaveMapper(
-        enhetsnummerService = enhetsnummerService,
-        pdlClient = pdlClient,
-        søknadRepository = søknadRepository,
-        unleashService = unleashService
-    )
+    private val barnetrygdOppgaveMapper =
+        BarnetrygdOppgaveMapper(
+            enhetsnummerService = enhetsnummerService,
+            pdlClient = pdlClient,
+            søknadRepository = søknadRepository,
+            unleashService = unleashService,
+        )
 
     @BeforeEach
     fun oppsett() {
@@ -51,16 +51,17 @@ class BarnetrygdOppgaveMapperTest {
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "132",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                        DokumentInfo(
-                            dokumentInfoId = "132",
-                            brevkode = Brevkoder.KLAGE,
-                        ),
-                    )
                 )
 
             // Act
@@ -78,12 +79,13 @@ class BarnetrygdOppgaveMapperTest {
                     journalpostId = "123",
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KLAGE,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                    )
                 )
 
             // Act
@@ -103,12 +105,13 @@ class BarnetrygdOppgaveMapperTest {
                     journalpostId = "123",
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KLAGE,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                    )
                 )
 
             // Act
@@ -130,24 +133,26 @@ class BarnetrygdOppgaveMapperTest {
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "132",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                        DokumentInfo(
-                            dokumentInfoId = "132",
-                            brevkode = Brevkoder.KLAGE,
-                        ),
-                    )
                 )
 
-            every { søknadRepository.getByJournalpostId(journalpost.journalpostId) } returns DBBarnetrygdSøknad(
-                id = 0,
-                objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
-                "12345678093",
-                LocalDateTime.now(),
-            )
+            every { søknadRepository.getByJournalpostId(journalpost.journalpostId) } returns
+                DBBarnetrygdSøknad(
+                    id = 0,
+                    objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
+                    "12345678093",
+                    LocalDateTime.now(),
+                )
 
             // Act
             val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
@@ -164,12 +169,13 @@ class BarnetrygdOppgaveMapperTest {
                     journalpostId = "123",
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KLAGE,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                    )
                 )
 
             // Act
@@ -189,12 +195,13 @@ class BarnetrygdOppgaveMapperTest {
                     journalpostId = "123",
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KLAGE,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                    )
                 )
 
             // Act

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
@@ -1,0 +1,150 @@
+package no.nav.familie.baks.mottak.integrasjoner
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.søknad.SøknadTestData
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
+import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadTestData
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
+import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
+import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
+import no.nav.familie.kontrakter.felles.journalpost.Journalpost
+import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
+import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class KontantstøtteOppgaveMapperTest {
+
+    private val enhetsnummerService: EnhetsnummerService = mockk()
+    private val pdlClient: PdlClient = mockk()
+    private val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
+
+    private val kontantstøtteOppgaveMapper = KontantstøtteOppgaveMapper(
+        enhetsnummerService = enhetsnummerService,
+        pdlClient = pdlClient,
+        kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
+        unleashService = unleashService
+    )
+
+    @BeforeEach
+    fun oppsett() {
+        every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns true
+    }
+
+    @Nested
+    inner class HentBehandlingstemaTest {
+        @Test
+        fun `skal returnere null for behandlingstema    `() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                )
+
+            // Act
+            val behandlingstema = kontantstøtteOppgaveMapper.hentBehandlingstema(journalpost)
+
+            // Assert
+            assertThat(behandlingstema).isNull()
+        }
+    }
+
+    @Nested
+    inner class HentBehandlingstypeTest {
+        @Test
+        fun `skal returnere NASJON hvis man har dokumenter for både kontantstøtte NASJONAL søknad og klage, og er digital`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "132",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            every { kontantstøtteSøknadRepository.getByJournalpostId(journalpost.journalpostId) } returns DBKontantstøtteSøknad(
+                id = 0,
+                objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
+                "12345678093",
+                LocalDateTime.now(),
+            )
+
+            // Act
+            val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isEqualTo(Behandlingstype.NASJONAL)
+        }
+
+        @Test
+        fun `skal returnere behandlingstype klage hvis man har dokumenter for klage`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isEqualTo(Behandlingstype.Klage)
+        }
+
+        @Test
+        fun `skal returnere behandlingstype NASJONAL hvis man har dokumenter for klage men toggle er skrudd av`() {
+            // Arrange
+            every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns false
+
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    dokumenter = listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "321",
+                            brevkode = Brevkoder.KLAGE,
+                        ),
+                    )
+                )
+
+            // Act
+            val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isEqualTo(Behandlingstype.NASJONAL)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
@@ -4,9 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
-import no.nav.familie.baks.mottak.søknad.SøknadTestData
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
-import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadTestData
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
@@ -24,18 +21,18 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class KontantstøtteOppgaveMapperTest {
-
     private val enhetsnummerService: EnhetsnummerService = mockk()
     private val pdlClient: PdlClient = mockk()
     private val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository = mockk()
     private val unleashService: UnleashNextMedContextService = mockk()
 
-    private val kontantstøtteOppgaveMapper = KontantstøtteOppgaveMapper(
-        enhetsnummerService = enhetsnummerService,
-        pdlClient = pdlClient,
-        kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
-        unleashService = unleashService
-    )
+    private val kontantstøtteOppgaveMapper =
+        KontantstøtteOppgaveMapper(
+            enhetsnummerService = enhetsnummerService,
+            pdlClient = pdlClient,
+            kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
+            unleashService = unleashService,
+        )
 
     @BeforeEach
     fun oppsett() {
@@ -73,24 +70,26 @@ class KontantstøtteOppgaveMapperTest {
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "132",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                        DokumentInfo(
-                            dokumentInfoId = "132",
-                            brevkode = Brevkoder.KLAGE,
-                        ),
-                    )
                 )
 
-            every { kontantstøtteSøknadRepository.getByJournalpostId(journalpost.journalpostId) } returns DBKontantstøtteSøknad(
-                id = 0,
-                objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
-                "12345678093",
-                LocalDateTime.now(),
-            )
+            every { kontantstøtteSøknadRepository.getByJournalpostId(journalpost.journalpostId) } returns
+                DBKontantstøtteSøknad(
+                    id = 0,
+                    objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
+                    "12345678093",
+                    LocalDateTime.now(),
+                )
 
             // Act
             val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)
@@ -107,12 +106,13 @@ class KontantstøtteOppgaveMapperTest {
                     journalpostId = "123",
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KLAGE,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                    )
                 )
 
             // Act
@@ -132,12 +132,13 @@ class KontantstøtteOppgaveMapperTest {
                     journalpostId = "123",
                     journalposttype = Journalposttype.I,
                     journalstatus = Journalstatus.MOTTATT,
-                    dokumenter = listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "321",
-                            brevkode = Brevkoder.KLAGE,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
                         ),
-                    )
                 )
 
             // Act

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -46,7 +46,7 @@ class OppgaveMapperTest(
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             søknadRepository = barnetrygdSøknadRepository,
-            unleashService = unleashService
+            unleashService = unleashService,
         )
 
     private val kontantstøtteOppgaveMapper: IOppgaveMapper =
@@ -54,7 +54,7 @@ class OppgaveMapperTest(
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
-            unleashService = unleashService
+            unleashService = unleashService,
         )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -3,6 +3,8 @@ package no.nav.familie.baks.mottak.integrasjoner
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.mottak.DevLauncher
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -37,12 +39,14 @@ class OppgaveMapperTest(
     private val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
 ) {
     private val mockEnhetsnummerService: EnhetsnummerService = mockk()
+    private val unleashService: UnleashNextMedContextService = mockk()
 
     private val barnetrygdOppgaveMapper: IOppgaveMapper =
         BarnetrygdOppgaveMapper(
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             søknadRepository = barnetrygdSøknadRepository,
+            unleashService = unleashService
         )
 
     private val kontantstøtteOppgaveMapper: IOppgaveMapper =
@@ -50,11 +54,13 @@ class OppgaveMapperTest(
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
+            unleashService = unleashService
         )
 
     @BeforeEach
     fun beforeEach() {
         every { mockEnhetsnummerService.hentEnhetsnummer(any()) } returns "1234"
+        every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns true
     }
 
     @Test


### PR DESCRIPTION
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Setter `behandlingstema` til `null` og `behandlingstype` til `Klage` når man har dokumenter på journalposten som omfatter klage. 

Har antatt at man ikke kun skal se på digitale klager her, bruker derfor ikke metoden `journalpost.harDigitalKlage()`. 