### PR TITLE
NAV-24901: Setter behandlingstype når det er en bruker med dnummer på journalposten

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -49,6 +49,7 @@ class BarnetrygdOppgaveMapper(
                     Behandlingstype.NASJONAL
                 }
 
+            erDnummerPåJournalpost(journalpost) -> null
             hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> Behandlingstype.Utland
             journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> Behandlingstype.Klage
             else -> null

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
@@ -9,6 +9,8 @@ import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.journalpost.Bruker
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
@@ -159,6 +161,36 @@ class BarnetrygdOppgaveMapperTest {
 
             // Assert
             assertThat(behandlingstype).isEqualTo(Behandlingstype.EØS)
+        }
+
+        @Test
+        fun `skal returnere behandlingstype null når brukeren har et dnummer og det ikke er en digital kanal`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = null,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
+                        ),
+                    bruker =
+                        Bruker(
+                            id = "41018512345",
+                            type = BrukerIdType.FNR,
+                        ),
+                )
+
+            // Act
+            val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isNull()
         }
 
         @Test


### PR DESCRIPTION
Favro: [NAV-24901](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24901)

I prod får vi feilmeldingen "Behandlingstema: ab0058 og behandlingstype: ae0058 er ikke gyldig for tema: BAR"

ab0058 = BarnetrygdEØS
ae0058 = Klage


Behandlingstema `BarnetrygdEØS` blir satt når det er et dnummer i journalposten.

Introduserer en sjekk slik at behandlingstypen `null` blir satt når det er et dnummer i journalposten.

Her kunne man også ha vurdert å bruke `Behandlingstype.EØS`, men da må man også gjøre endringer her: https://github.com/navikt/oppgave/blob/master/src/main/resources/data/gjelder.json#L173