### PR TITLE
NAV-24901: Setter tema og type for journalposter med klagedokument(er). Fjerner toggle som har vært skrudd på i prod en stund.

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
@@ -8,7 +8,6 @@ class FeatureToggleConfig {
         // Release
         const val AUTOMATISK_JOURNALFØRING_AV_KONTANTSTØTTE_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ks-soknad"
         const val AUTOMATISK_JOURNALFØRING_AV_BARNETRYGD_SØKNADER = "familie-baks-mottak.automatisk-journalforing-av-ba-soknad"
-        const val SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE = "familie-baks-mottak.sett-behandlingstema-og-behandlingstype-for-klage"
 
         // Ny pdf kvittering
         const val NY_FAMILIE_PDF_KVITTERING = "familie-ba-soknad.ny-pdf"

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -14,9 +14,9 @@ class BarnetrygdOppgaveMapper(
     pdlClient: PdlClient,
     val søknadRepository: SøknadRepository,
 ) : AbstractOppgaveMapper(
-    enhetsnummerService = enhetsnummerService,
-    pdlClient = pdlClient,
-) {
+        enhetsnummerService = enhetsnummerService,
+        pdlClient = pdlClient,
+    ) {
     override val tema: Tema = Tema.BAR
 
     // Behandlingstema og behandlingstype settes basert på regelsettet som er dokumentert nederst her: https://confluence.adeo.no/display/TFA/Mottak+av+dokumenter

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -15,11 +15,10 @@ class BarnetrygdOppgaveMapper(
     enhetsnummerService: EnhetsnummerService,
     pdlClient: PdlClient,
     val søknadRepository: SøknadRepository,
-    private val unleashService: UnleashNextMedContextService,
 ) : AbstractOppgaveMapper(
-        enhetsnummerService = enhetsnummerService,
-        pdlClient = pdlClient,
-    ) {
+    enhetsnummerService = enhetsnummerService,
+    pdlClient = pdlClient,
+) {
     override val tema: Tema = Tema.BAR
 
     // Behandlingstema og behandlingstype settes basert på regelsettet som er dokumentert nederst her: https://confluence.adeo.no/display/TFA/Mottak+av+dokumenter
@@ -32,9 +31,9 @@ class BarnetrygdOppgaveMapper(
                     Behandlingstema.OrdinærBarnetrygd
                 }
 
-            erDnummerPåJournalpost(journalpost) -> Behandlingstema.BarnetrygdEØS
+            !journalpost.harKlage() && erDnummerPåJournalpost(journalpost) -> Behandlingstema.BarnetrygdEØS
             hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> null
-            journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> null
+            journalpost.harKlage() -> null
             else -> Behandlingstema.OrdinærBarnetrygd
         }
 
@@ -50,7 +49,7 @@ class BarnetrygdOppgaveMapper(
                 }
 
             hoveddokumentErÅrligDifferanseutbetalingAvBarnetrygd(journalpost) -> Behandlingstype.Utland
-            journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> Behandlingstype.Klage
+            journalpost.harKlage() -> Behandlingstype.Klage
             else -> null
         }
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.harEøsSteg
 import no.nav.familie.kontrakter.felles.Behandlingstema

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.baks.mottak.integrasjoner
 
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.harEøsSteg
 import no.nav.familie.kontrakter.felles.Behandlingstema

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -36,7 +36,7 @@ class KontantstøtteOppgaveMapper(
                     Behandlingstype.NASJONAL
                 }
 
-            erDnummerPåJournalpost(journalpost) -> Behandlingstype.EØS
+            !journalpost.harKlage() && erDnummerPåJournalpost(journalpost) -> Behandlingstype.EØS
             journalpost.harKlage() -> Behandlingstype.Klage
             else -> Behandlingstype.NASJONAL
         }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapper.kt
@@ -15,7 +15,6 @@ class KontantstøtteOppgaveMapper(
     enhetsnummerService: EnhetsnummerService,
     pdlClient: PdlClient,
     val kontantstøtteSøknadRepository: KontantstøtteSøknadRepository,
-    private val unleashService: UnleashNextMedContextService,
 ) : AbstractOppgaveMapper(
         enhetsnummerService = enhetsnummerService,
         pdlClient = pdlClient,
@@ -38,7 +37,7 @@ class KontantstøtteOppgaveMapper(
                 }
 
             erDnummerPåJournalpost(journalpost) -> Behandlingstype.EØS
-            journalpost.harKlage() && unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) -> Behandlingstype.Klage
+            journalpost.harKlage() -> Behandlingstype.Klage
             else -> Behandlingstype.NASJONAL
         }
 

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
@@ -111,7 +111,7 @@ class BarnetrygdOppgaveMapperTest {
             val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
 
             // Assert
-            assertThat(behandlingstema).isEqualTo(null)
+            assertThat(behandlingstema).isNull()
         }
 
         @Test

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
@@ -2,8 +2,6 @@ package no.nav.familie.baks.mottak.integrasjoner
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.SøknadTestData
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
@@ -18,7 +16,6 @@ import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -167,12 +164,12 @@ class BarnetrygdOppgaveMapperTest {
                 )
 
             every { søknadRepository.getByJournalpostId(journalpost.journalpostId) } returns
-                    DBBarnetrygdSøknad(
-                        id = 0,
-                        objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
-                        "12345678093",
-                        LocalDateTime.now(),
-                    )
+                DBBarnetrygdSøknad(
+                    id = 0,
+                    søknadJson = objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
+                    fnr = "12345678093",
+                    opprettetTid = LocalDateTime.now(),
+                )
 
             // Act
             val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapperTest.kt
@@ -9,6 +9,8 @@ import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.DBBarnetrygdSøknad
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.BrukerIdType
+import no.nav.familie.kontrakter.felles.journalpost.Bruker
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
@@ -25,20 +27,13 @@ class BarnetrygdOppgaveMapperTest {
     private val enhetsnummerService: EnhetsnummerService = mockk()
     private val pdlClient: PdlClient = mockk()
     private val søknadRepository: SøknadRepository = mockk()
-    private val unleashService: UnleashNextMedContextService = mockk()
 
     private val barnetrygdOppgaveMapper =
         BarnetrygdOppgaveMapper(
             enhetsnummerService = enhetsnummerService,
             pdlClient = pdlClient,
             søknadRepository = søknadRepository,
-            unleashService = unleashService,
         )
-
-    @BeforeEach
-    fun oppsett() {
-        every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns true
-    }
 
     @Nested
     inner class HentBehandlingstema {
@@ -72,7 +67,58 @@ class BarnetrygdOppgaveMapperTest {
         }
 
         @Test
-        fun `skal returnere null for klage`() {
+        fun `skal returnere barnetrygd eøs for journalposter med ba ordinær søknad dokument og som har dnummer men ikke er digital`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    bruker = Bruker("41018512345", type = BrukerIdType.FNR),
+                    kanal = null,
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
+                        ),
+                )
+
+            // Act
+            val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
+
+            // Assert
+            assertThat(behandlingstema).isEqualTo(Behandlingstema.BarnetrygdEØS)
+        }
+
+        @Test
+        fun `skal returnere null for journalpost med klagedokument og med dnummer`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    bruker = Bruker(id = "41018512345", type = BrukerIdType.FNR),
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
+                        ),
+                )
+
+            // Act
+            val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
+
+            // Assert
+            assertThat(behandlingstema).isEqualTo(null)
+        }
+
+        @Test
+        fun `skal returnere null for journalpost med klagedokument`() {
             // Arrange
             val journalpost =
                 Journalpost(
@@ -93,32 +139,6 @@ class BarnetrygdOppgaveMapperTest {
 
             // Assert
             assertThat(behandlingstema).isNull()
-        }
-
-        @Test
-        fun `skal returnere ordinær barnetrygd for klage hvis toggle er skrudd av`() {
-            // Arrange
-            every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns false
-
-            val journalpost =
-                Journalpost(
-                    journalpostId = "123",
-                    journalposttype = Journalposttype.I,
-                    journalstatus = Journalstatus.MOTTATT,
-                    dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "321",
-                                brevkode = Brevkoder.KLAGE,
-                            ),
-                        ),
-                )
-
-            // Act
-            val behandlingstema = barnetrygdOppgaveMapper.hentBehandlingstema(journalpost)
-
-            // Assert
-            assertThat(behandlingstema).isEqualTo(Behandlingstema.OrdinærBarnetrygd)
         }
     }
 
@@ -147,12 +167,12 @@ class BarnetrygdOppgaveMapperTest {
                 )
 
             every { søknadRepository.getByJournalpostId(journalpost.journalpostId) } returns
-                DBBarnetrygdSøknad(
-                    id = 0,
-                    objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
-                    "12345678093",
-                    LocalDateTime.now(),
-                )
+                    DBBarnetrygdSøknad(
+                        id = 0,
+                        objectMapper.writeValueAsString(SøknadTestData.barnetrygdSøknad()),
+                        "12345678093",
+                        LocalDateTime.now(),
+                    )
 
             // Act
             val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
@@ -183,32 +203,6 @@ class BarnetrygdOppgaveMapperTest {
 
             // Assert
             assertThat(behandlingstype).isEqualTo(Behandlingstype.Klage)
-        }
-
-        @Test
-        fun `skal returnere behandlingstype null hvis man har dokumenter for klage men toggle er skrudd av`() {
-            // Arrange
-            every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns false
-
-            val journalpost =
-                Journalpost(
-                    journalpostId = "123",
-                    journalposttype = Journalposttype.I,
-                    journalstatus = Journalstatus.MOTTATT,
-                    dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "321",
-                                brevkode = Brevkoder.KLAGE,
-                            ),
-                        ),
-                )
-
-            // Act
-            val behandlingstype = barnetrygdOppgaveMapper.hentBehandlingstype(journalpost)
-
-            // Assert
-            assertThat(behandlingstype).isNull()
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
@@ -130,6 +130,33 @@ class KontantstøtteOppgaveMapperTest {
         }
 
         @Test
+        fun `skal returnere behandlingstype klage hvis man har dokumenter for klage og journalpost inneholder dnummer`() {
+            // Arrange
+            val dnummer = "41018512345"
+
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    bruker = Bruker(id = dnummer, type = BrukerIdType.FNR),
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "321",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
+                        ),
+                )
+
+            // Act
+            val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)
+
+            // Assert
+            assertThat(behandlingstype).isEqualTo(Behandlingstype.Klage)
+        }
+
+        @Test
         fun `skal returnere behandlingstype klage hvis man har dokumenter for klage`() {
             // Arrange
             val journalpost =

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/KontantstøtteOppgaveMapperTest.kt
@@ -2,8 +2,6 @@ package no.nav.familie.baks.mottak.integrasjoner
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.KontantstøtteSøknadTestData
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.DBKontantstøtteSøknad
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository
@@ -17,7 +15,6 @@ import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.Behandlingstype
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -79,12 +76,12 @@ class KontantstøtteOppgaveMapperTest {
                 )
 
             every { kontantstøtteSøknadRepository.getByJournalpostId(journalpost.journalpostId) } returns
-                    DBKontantstøtteSøknad(
-                        id = 0,
-                        søknadJson = objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
-                        fnr = "12345678093",
-                        opprettetTid = LocalDateTime.now(),
-                    )
+                DBKontantstøtteSøknad(
+                    id = 0,
+                    søknadJson = objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
+                    fnr = "12345678093",
+                    opprettetTid = LocalDateTime.now(),
+                )
 
             // Act
             val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)
@@ -115,12 +112,12 @@ class KontantstøtteOppgaveMapperTest {
                 )
 
             every { kontantstøtteSøknadRepository.getByJournalpostId(journalpost.journalpostId) } returns
-                    DBKontantstøtteSøknad(
-                        id = 0,
-                        søknadJson = objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
-                        fnr = dnummer,
-                        opprettetTid = LocalDateTime.now(),
-                    )
+                DBKontantstøtteSøknad(
+                    id = 0,
+                    søknadJson = objectMapper.writeValueAsString(KontantstøtteSøknadTestData.kontantstøtteSøknad()),
+                    fnr = dnummer,
+                    opprettetTid = LocalDateTime.now(),
+                )
 
             // Act
             val behandlingstype = kontantstøtteOppgaveMapper.hentBehandlingstype(journalpost)

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.baks.mottak.integrasjoner
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.baks.mottak.DevLauncher
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.søknad.barnetrygd.domene.SøknadRepository
 import no.nav.familie.baks.mottak.søknad.kontantstøtte.domene.KontantstøtteSøknadRepository

--- a/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveMapperTest.kt
@@ -46,7 +46,6 @@ class OppgaveMapperTest(
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             søknadRepository = barnetrygdSøknadRepository,
-            unleashService = unleashService,
         )
 
     private val kontantstøtteOppgaveMapper: IOppgaveMapper =
@@ -54,13 +53,11 @@ class OppgaveMapperTest(
             enhetsnummerService = mockEnhetsnummerService,
             pdlClient = mockPdlClient,
             kontantstøtteSøknadRepository = kontantstøtteSøknadRepository,
-            unleashService = unleashService,
         )
 
     @BeforeEach
     fun beforeEach() {
         every { mockEnhetsnummerService.hentEnhetsnummer(any()) } returns "1234"
-        every { unleashService.isEnabled(FeatureToggleConfig.SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_KLAGE, false) } returns true
     }
 
     @Test


### PR DESCRIPTION
Favro: [NAV-24901](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24901)

Får følgende feilmelding i prod: `Behandlingstema: ab0058 og behandlingstype: ae0058 er ikke gyldig for tema: BAR` 

ab0058 = BarnetrygdEØS
ae0058 = Klage

Det er en ugydlig kombinasjon. Sørger for at vi ikke setter `Behandlingstema.BarnetrygdEØS` hvis man får inn en journalpost med klagedokumenter som også har et dnummer. 

Fjerner toggle da den har vært skrudd på i prod en stund nå og hadde ikke lyst til å skrive ekstra kode rundt den nå. 
