### PR TITLE
Vi tillater automatisk journalføring av journalposter når enhet er 2103 eller det finnes strengt fortrolig personer når toggle er på

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggleConfig.kt
@@ -5,6 +5,9 @@ class FeatureToggleConfig {
         // Operasjonelle
         const val HOPP_OVER_INFOTRYGD_SJEKK = "familie-ba-sak.hopp-over-infotrygd-sjekk"
 
+        // Operasjonelle
+        const val AUTOMATISK_JOURNALFØR_ENHET_2103 = "familie-ba-sak.tillatt-behandling-av-kode6-kode19"
+
         // Ny pdf kvittering
         const val NY_FAMILIE_PDF_KVITTERING = "familie-ba-soknad.ny-pdf"
     }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/journalføring/AdressebeskyttelesesgraderingService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/journalføring/AdressebeskyttelesesgraderingService.kt
@@ -36,6 +36,16 @@ class AdressebeskyttelesesgraderingService(
             .any { it.gradering.erStrengtFortrolig() }
     }
 
+    fun finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
+        tema: Tema,
+        journalpost: Journalpost,
+    ): Boolean {
+        val journalpostBruker = journalpost.bruker ?: throw IllegalStateException("Bruker på journalpost ${journalpost.journalpostId} kan ikke være null")
+        val journalpostBrukerIdent = journalpostBrukerService.tilPersonIdent(journalpostBruker, tema)
+
+        return pdlClient.hentPerson(journalpostBrukerIdent, "hentperson-med-adressebeskyttelse", tema).adressebeskyttelse.any { it.gradering.erStrengtFortrolig() }
+    }
+
     private fun finnIdenterForKontantstøtte(
         tema: Tema,
         bruker: Bruker,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdService.kt
@@ -45,9 +45,15 @@ class AutomatiskJournalføringBarnetrygdService(
             return false
         }
 
-        if (!kode6Og19ToggleErPå &&
-            adressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(tema, journalpost)
-        ) {
+        val noenHarKode6Eller19 = adressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(tema, journalpost)
+
+        if (kode6Og19ToggleErPå) {
+            val søkerHarKode6Eller19 = adressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(tema, journalpost)
+
+            if (!søkerHarKode6Eller19 && noenHarKode6Eller19) {
+                return false
+            }
+        } else if (noenHarKode6Eller19) {
             return false
         }
 

--- a/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdServiceTest.kt
@@ -185,6 +185,13 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
         } returns false
 
         every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
             mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
                 personIdent = identifikator,
                 tema = Tema.BAR,
@@ -268,6 +275,13 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
         every {
             mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
                 tema = Tema.BAR,
                 journalpost = journalpost,
             )
@@ -371,7 +385,94 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
     }
 
     @Test
-    fun `skal automatisk journalføre journalpost hvis det finnes en tilknyttet strengt fortrolig person og toggle er på`() {
+    fun `skal automatisk journalføre journalpost hvis søker er en strengt fortrolig person og toggle er på`() {
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
+
+        // Arrange
+        val identifikator = "123"
+        val fagsakId = 1L
+
+        val journalpost =
+            Journalpost(
+                journalpostId = "1",
+                journalposttype = Journalposttype.I,
+                journalstatus = Journalstatus.MOTTATT,
+                bruker =
+                    Bruker(
+                        id = identifikator,
+                        type = BrukerIdType.FNR,
+                    ),
+                kanal = "NAV_NO",
+                dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            brevkode = "NAV 33-00.07",
+                            tittel = "Søknad",
+                            dokumentstatus = Dokumentstatus.FERDIGSTILT,
+                            dokumentvarianter = emptyList(),
+                            dokumentInfoId = "id",
+                        ),
+                    ),
+            )
+
+        every {
+            mockedJournalpostBrukerService.tilPersonIdent(
+                bruker = journalpost.bruker!!,
+                tema = Tema.BAR,
+            )
+        } returns identifikator
+
+        every { mockedBaSakClient.hentFagsaknummerPåPersonident(any()) } returns fagsakId
+
+        every {
+            mockedBaSakClient.hentMinimalRestFagsak(
+                fagsakId = fagsakId,
+            )
+        } returns
+            RestMinimalFagsak(
+                id = fagsakId,
+                behandlinger = listOf(),
+                status = FagsakStatus.LØPENDE,
+            )
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns true
+
+        every {
+            mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
+                personIdent = identifikator,
+                tema = Tema.BAR,
+            )
+        } returns
+            Enhet(
+                enhetId = "enhetId",
+                enhetNavn = "enhetNavn",
+            )
+
+        // Act
+        val skalAutomatiskJournalføres =
+            automatiskJournalføringBarnetrygdService.skalAutomatiskJournalføres(
+                journalpost,
+                false,
+            )
+
+        // Assert
+        assertThat(skalAutomatiskJournalføres).isTrue()
+    }
+
+    @Test
+    fun `skal ikke automatisk journalføre journalpost hvis søker ikke er en strengt fortrolig person men barna er og toggle er på`() {
         every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
 
         // Arrange
@@ -429,6 +530,13 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
         } returns true
 
         every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
             mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
                 personIdent = identifikator,
                 tema = Tema.BAR,
@@ -447,7 +555,7 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
             )
 
         // Assert
-        assertThat(skalAutomatiskJournalføres).isTrue()
+        assertThat(skalAutomatiskJournalføres).isFalse()
     }
 
     @Test
@@ -501,6 +609,13 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
         every {
             mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
                 tema = Tema.BAR,
                 journalpost = journalpost,
             )
@@ -667,6 +782,20 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
         } returns false
 
         every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns true
+
+        every {
             mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
                 personIdent = identifikator,
                 tema = Tema.BAR,
@@ -739,6 +868,13 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
         every {
             mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(
                 tema = Tema.BAR,
                 journalpost = journalpost,
             )

--- a/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.baks.mottak.journalføring
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
 import no.nav.familie.baks.mottak.integrasjoner.ArbeidsfordelingClient
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.BehandlingKategori
@@ -22,6 +23,7 @@ import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.unleash.UnleashService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
@@ -39,6 +41,11 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
             adressebeskyttelesesgraderingService = mockedAdressebeskyttelesesgraderingService,
             journalpostBrukerService = mockedJournalpostBrukerService,
         )
+
+    @BeforeEach
+    internal fun setUp() {
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
+    }
 
     @Test
     fun `skal ikke automatisk journalføre journalpost om journalposten ikke er barnetrygd`() {
@@ -317,10 +324,10 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
     }
 
     @Test
-    fun `skal ikke automatisk journalføre journalpost hvis det finnes en tilknyttet strengt fortrolig person`() {
+    fun `skal ikke automatisk journalføre journalpost hvis det finnes en tilknyttet strengt fortrolig person og toggle er ikke på`() {
         // Arrange
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns false
         val identifikator = "123"
-        val fagsakId = 1L
 
         val journalpost =
             Journalpost(
@@ -361,6 +368,86 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
         // Assert
         assertThat(skalAutomatiskJournalføres).isFalse()
+    }
+
+    @Test
+    fun `skal automatisk journalføre journalpost hvis det finnes en tilknyttet strengt fortrolig person og toggle er på`() {
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
+
+        // Arrange
+        val identifikator = "123"
+        val fagsakId = 1L
+
+        val journalpost =
+            Journalpost(
+                journalpostId = "1",
+                journalposttype = Journalposttype.I,
+                journalstatus = Journalstatus.MOTTATT,
+                bruker =
+                    Bruker(
+                        id = identifikator,
+                        type = BrukerIdType.FNR,
+                    ),
+                kanal = "NAV_NO",
+                dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            brevkode = "NAV 33-00.07",
+                            tittel = "Søknad",
+                            dokumentstatus = Dokumentstatus.FERDIGSTILT,
+                            dokumentvarianter = emptyList(),
+                            dokumentInfoId = "id",
+                        ),
+                    ),
+            )
+
+        every {
+            mockedJournalpostBrukerService.tilPersonIdent(
+                bruker = journalpost.bruker!!,
+                tema = Tema.BAR,
+            )
+        } returns identifikator
+
+        every { mockedBaSakClient.hentFagsaknummerPåPersonident(any()) } returns fagsakId
+
+        every {
+            mockedBaSakClient.hentMinimalRestFagsak(
+                fagsakId = fagsakId,
+            )
+        } returns
+            RestMinimalFagsak(
+                id = fagsakId,
+                behandlinger = listOf(),
+                status = FagsakStatus.LØPENDE,
+            )
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns true
+
+        every {
+            mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
+                personIdent = identifikator,
+                tema = Tema.BAR,
+            )
+        } returns
+            Enhet(
+                enhetId = "enhetId",
+                enhetNavn = "enhetNavn",
+            )
+
+        // Act
+        val skalAutomatiskJournalføres =
+            automatiskJournalføringBarnetrygdService.skalAutomatiskJournalføres(
+                journalpost,
+                false,
+            )
+
+        // Assert
+        assertThat(skalAutomatiskJournalføres).isTrue()
     }
 
     @Test
@@ -439,6 +526,166 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
         // Assert
         assertThat(skalAutomatiskJournalføres).isFalse()
+    }
+
+    @Test
+    fun `skal ikke automatisk journalføre journalpost hvis enhet er 2103 og toggle er av`() {
+        // Arrange
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns false
+
+        val identifikator = "123"
+        val fagsakId = 1L
+
+        val journalpost =
+            Journalpost(
+                journalpostId = "1",
+                journalposttype = Journalposttype.I,
+                journalstatus = Journalstatus.MOTTATT,
+                bruker =
+                    Bruker(
+                        id = identifikator,
+                        type = BrukerIdType.FNR,
+                    ),
+                kanal = "NAV_NO",
+                dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            brevkode = "NAV 33-00.07",
+                            tittel = "Søknad",
+                            dokumentstatus = Dokumentstatus.FERDIGSTILT,
+                            dokumentvarianter = emptyList(),
+                            dokumentInfoId = "id",
+                        ),
+                    ),
+            )
+
+        every {
+            mockedJournalpostBrukerService.tilPersonIdent(
+                bruker = journalpost.bruker!!,
+                tema = Tema.BAR,
+            )
+        } returns identifikator
+
+        every { mockedBaSakClient.hentFagsaknummerPåPersonident(any()) } returns fagsakId
+
+        every {
+            mockedBaSakClient.hentMinimalRestFagsak(
+                fagsakId = fagsakId,
+            )
+        } returns
+            RestMinimalFagsak(
+                id = fagsakId,
+                behandlinger = listOf(),
+                status = FagsakStatus.LØPENDE,
+            )
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
+                personIdent = identifikator,
+                tema = Tema.BAR,
+            )
+        } returns
+            Enhet(
+                enhetId = "2103",
+                enhetNavn = "Vikafossen",
+            )
+
+        // Act
+        val skalAutomatiskJournalføres =
+            automatiskJournalføringBarnetrygdService.skalAutomatiskJournalføres(
+                journalpost,
+                false,
+            )
+
+        // Assert
+        assertThat(skalAutomatiskJournalføres).isFalse()
+    }
+
+    @Test
+    fun `skal automatisk journalføre journalpost hvis enhet er 2103 og toggle er på`() {
+        // Arrange
+        every { mockedUnleashService.isEnabled(FeatureToggleConfig.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
+
+        val identifikator = "123"
+        val fagsakId = 1L
+
+        val journalpost =
+            Journalpost(
+                journalpostId = "1",
+                journalposttype = Journalposttype.I,
+                journalstatus = Journalstatus.MOTTATT,
+                bruker =
+                    Bruker(
+                        id = identifikator,
+                        type = BrukerIdType.FNR,
+                    ),
+                kanal = "NAV_NO",
+                dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            brevkode = "NAV 33-00.07",
+                            tittel = "Søknad",
+                            dokumentstatus = Dokumentstatus.FERDIGSTILT,
+                            dokumentvarianter = emptyList(),
+                            dokumentInfoId = "id",
+                        ),
+                    ),
+            )
+
+        every {
+            mockedJournalpostBrukerService.tilPersonIdent(
+                bruker = journalpost.bruker!!,
+                tema = Tema.BAR,
+            )
+        } returns identifikator
+
+        every { mockedBaSakClient.hentFagsaknummerPåPersonident(any()) } returns fagsakId
+
+        every {
+            mockedBaSakClient.hentMinimalRestFagsak(
+                fagsakId = fagsakId,
+            )
+        } returns
+            RestMinimalFagsak(
+                id = fagsakId,
+                behandlinger = listOf(),
+                status = FagsakStatus.LØPENDE,
+            )
+
+        every {
+            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
+                tema = Tema.BAR,
+                journalpost = journalpost,
+            )
+        } returns false
+
+        every {
+            mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
+                personIdent = identifikator,
+                tema = Tema.BAR,
+            )
+        } returns
+            Enhet(
+                enhetId = "2103",
+                enhetNavn = "Vikafossen",
+            )
+
+        // Act
+        val skalAutomatiskJournalføres =
+            automatiskJournalføringBarnetrygdService.skalAutomatiskJournalføres(
+                journalpost,
+                false,
+            )
+
+        // Assert
+        assertThat(skalAutomatiskJournalføres).isTrue()
     }
 
     @Test


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25187

Når toggle er på ønsker vi at 

- Journalpost som går til enhet 2103 nå skal automatisk journalføres (gitt at andre sjekk er OK)
- Hvis søker av søknad har kode 6/19 så skal det automatisk journalføres (gitt at andre sjekk er OK)
- Hvis søker av søknad ikke har kode 6/19 men barn har, så skal det ikke automatisk journalføres 
- Hvis ingen har kode 6/19, automatisk journalfør (gitt at andre sjekk er OK)