### PR TITLE
Sett tidligste triggertid for Svalbard- og Finnmarkstillegg tasker

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
@@ -271,7 +271,7 @@ class LeesahService(
                 return
             }
 
-        taskService.save(nyTask.medTriggerTid(plussEnTimeIProd()))
+        taskService.save(nyTask.medTriggerTid(finnTriggerTidSvalbardOgFinnmarkstilleggTask()))
     }
 
     private fun oppdaterEksisterendeFinnmarkstilleggTask(
@@ -332,13 +332,19 @@ class LeesahService(
                     this["ident"] = pdlHendelse.hentPersonident()
                     this["callId"] = pdlHendelse.hendelseId
                 },
-        ).medTriggerTid(plussEnTimeIProd())
+        ).medTriggerTid(finnTriggerTidSvalbardOgFinnmarkstilleggTask())
             .also { taskService.save(it) }
 
-    private fun plussEnTimeIProd(): LocalDateTime =
-        LocalDateTime.now().run {
-            if (environment.activeProfiles.contains("prod")) this.plusHours(1) else this
+    private fun finnTriggerTidSvalbardOgFinnmarkstilleggTask(): LocalDateTime {
+        val nåværendeTidspunkt = LocalDateTime.now()
+        val tidligsteTriggerTid = LocalDateTime.of(2025, 11, 1, 0, 0)
+
+        return if (!environment.activeProfiles.contains("prod")) {
+            return nåværendeTidspunkt
+        } else {
+            maxOf(nåværendeTidspunkt.plusHours(1), tidligsteTriggerTid)
         }
+    }
 
     private fun oppdaterHendelseslogg(pdlHendelse: PdlHendelse) {
         val metadata =

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
@@ -340,7 +340,7 @@ class LeesahService(
         val tidligsteTriggerTid = LocalDateTime.of(2025, 11, 1, 0, 0)
 
         return if (!environment.activeProfiles.contains("prod")) {
-            return nåværendeTidspunkt
+            nåværendeTidspunkt
         } else {
             maxOf(nåværendeTidspunkt.plusHours(1), tidligsteTriggerTid)
         }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26330)

Man kan melde inn flytting 31 dager frem i tid, så vi må lytte på adressehendelser i prod fra og med 1. oktober, men tasker skal ikke kjøres før 01. november. Setter tidligste triggertid for Svalbard- og Finnmarkstillegg tasker til 01.11.25 i prod. Pre-prod kjører fortsatt tasker umiddelbart.