### PR TITLE
Ikke opprett task for irrelevante adressehendelser

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/TriggFinnmarkstilleggbehandlingIBaSakTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/TriggFinnmarkstilleggbehandlingIBaSakTask.kt
@@ -1,0 +1,40 @@
+package no.nav.familie.baks.mottak.task
+
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig.Companion.SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE,
+    beskrivelse = "Trigger finnmarkstilleggbehandling i ba-sak",
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+)
+class TriggFinnmarkstilleggbehandlingIBaSakTask(
+    private val baSakClient: BaSakClient,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val ident = task.payload
+
+        if (unleashNextMedContextService.isEnabled(SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK)) {
+            baSakClient.sendFinnmarkstilleggTilBaSak(ident)
+        } else {
+            throw RekjørSenereException(
+                årsak = "Toggle er skrudd av, prøver igjen om 1 uke",
+                triggerTid = LocalDateTime.now().plusWeeks(1),
+            )
+        }
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "triggFinnmarkstilleggbehandlingIBaSakTask"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/TriggSvalbardtilleggbehandlingIBaSakTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/TriggSvalbardtilleggbehandlingIBaSakTask.kt
@@ -1,0 +1,40 @@
+package no.nav.familie.baks.mottak.task
+
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig.Companion.SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE,
+    beskrivelse = "Trigger svalbardtilleggbehandling i ba-sak",
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+)
+class TriggSvalbardtilleggbehandlingIBaSakTask(
+    private val baSakClient: BaSakClient,
+    private val unleashNextMedContextService: UnleashNextMedContextService,
+) : AsyncTaskStep {
+    override fun doTask(task: Task) {
+        val ident = task.payload
+
+        if (unleashNextMedContextService.isEnabled(SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK)) {
+            baSakClient.sendSvalbardtilleggTilBaSak(ident)
+        } else {
+            throw RekjørSenereException(
+                årsak = "Toggle er skrudd av, prøver igjen om 1 uke",
+                triggerTid = LocalDateTime.now().plusWeeks(1),
+            )
+        }
+    }
+
+    companion object {
+        const val TASK_STEP_TYPE = "TriggSvalbardtilleggbehandlingIBaSakTask"
+    }
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.baks.mottak.task
 
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms
@@ -14,28 +12,37 @@ import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTrom
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.personopplysning.Bostedsadresse
+import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
+import org.springframework.core.env.Environment
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.test.Test
 
 class FinnmarkstilleggTaskTest {
     private val mockBaSakClient: BaSakClient = mockk()
     private val mockPdlClient: PdlClient = mockk()
-    private val mockUnleashNextMedContextService: UnleashNextMedContextService = mockk(relaxed = true)
-    private val finnmarkstilleggTask = FinnmarkstilleggTask(mockPdlClient, mockBaSakClient, mockUnleashNextMedContextService)
+    private val mockTaskService: TaskService = mockk()
+    private val mockEnvironment: Environment = mockk(relaxed = true)
+    private val finnmarkstilleggTask = FinnmarkstilleggTask(mockPdlClient, mockBaSakClient, mockTaskService, mockEnvironment)
     private val personIdent = "123"
     private val osloKommunenummer = "0301"
 
     @BeforeEach
     fun setUp() {
-        every { mockUnleashNextMedContextService.isEnabled(any()) } returns true
+        every { mockTaskService.finnTaskMedPayloadOgType(any(), any()) } returns null
+        every { mockTaskService.save(any()) } returns mockk()
     }
 
     @Test
-    fun `ikke send melding om Finnmarkstillegg hvis bostedskommune fra hendelse er null`() {
+    fun `ikke opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis bostedskommune fra hendelse er null`() {
         // Arrange
         val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, null, LocalDate.now())
         val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
@@ -46,11 +53,11 @@ class FinnmarkstilleggTaskTest {
         // Assert
         verify(exactly = 0) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ikke send melding om Finnmarkstillegg hvis bostedskommuneFomDato fra hendelse er null`() {
+    fun `ikke opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis bostedskommuneFomDato fra hendelse er null`() {
         // Arrange
         val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, ALTA.kommunenummer, null)
         val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
@@ -61,11 +68,64 @@ class FinnmarkstilleggTaskTest {
         // Assert
         verify(exactly = 0) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status::class, names = ["KLAR_TIL_PLUKK", "UBEHANDLET"], mode = INCLUDE)
+    fun `hopp ut av FinnmarkstilleggTask som følge av eksisterende ukjørt TriggFinnmarkstilleggbehandlingIBaSakTask for ident`(
+        status: Status,
+    ) {
+        // Arrange
+        every { mockTaskService.finnTaskMedPayloadOgType(any(), any()) } returns
+            Task(
+                type = TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE,
+                payload = personIdent,
+                status = status,
+            )
+
+        val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, ALTA.kommunenummer, LocalDate.now())
+        val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
+
+        // Act
+        finnmarkstilleggTask.doTask(task)
+
+        // Assert
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
+        verify(exactly = 0) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
+        verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status::class, names = ["KLAR_TIL_PLUKK", "UBEHANDLET"], mode = EXCLUDE)
+    fun `ikke hopp ut av FinnmarkstilleggTask som følge av eksisterende ferdigkjørt TriggFinnmarkstilleggbehandlingIBaSakTask for ident`(
+        status: Status,
+    ) {
+        // Arrange
+        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns emptyList()
+        every { mockTaskService.finnTaskMedPayloadOgType(any(), any()) } returns
+            Task(
+                type = TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE,
+                payload = personIdent,
+                status = status,
+            )
+
+        val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, ALTA.kommunenummer, LocalDate.now())
+        val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
+
+        // Act
+        finnmarkstilleggTask.doTask(task)
+
+        // Assert
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
+        verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
+        verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ìkke send melding om Finnmarkstillegg hvis person ikke har bostedsadresse`() {
+    fun `ìkke opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis person ikke har bostedsadresse`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns emptyList()
 
@@ -78,11 +138,11 @@ class FinnmarkstilleggTaskTest {
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ikke send melding til ba-sak hvis person flytter fra en kommune som skal ha Finnmarkstillegg til en annen kommune som har Finnmarkstillegg`() {
+    fun `ikke opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis person flytter fra en kommune som skal ha Finnmarkstillegg til en annen kommune som har Finnmarkstillegg`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
             listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns ALTA.kommunenummer }))
@@ -96,11 +156,11 @@ class FinnmarkstilleggTaskTest {
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ikke send melding til ba-sak hvis person flytter fra en av kommune som ikke skal ha Finnmarkstillegg til en annen kommune som ikke har Finnmarkstillegg`() {
+    fun `ikke opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis person flytter fra en av kommune som ikke skal ha Finnmarkstillegg til en annen kommune som ikke har Finnmarkstillegg`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
             listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns osloKommunenummer }))
@@ -114,11 +174,11 @@ class FinnmarkstilleggTaskTest {
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ikke send melding om Finnmarkstillegg hvis person ikke har noen løpende saker`() {
+    fun `ikke opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis person ikke har noen løpende saker`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
             listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns osloKommunenummer }))
@@ -133,38 +193,16 @@ class FinnmarkstilleggTaskTest {
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
-    }
-
-    @Test
-    fun `ikke send melding om Finnmarkstillegg hvis toggle er skrudd av`() {
-        // Arrange
-        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
-            listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns osloKommunenummer }))
-        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
-        every { mockUnleashNextMedContextService.isEnabled(FeatureToggleConfig.SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK) } returns false
-
-        val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, ALTA.kommunenummer, LocalDate.now())
-        val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
-
-        // Act
-        finnmarkstilleggTask.doTask(task)
-
-        // Assert
-        verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
-        verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 1) { mockUnleashNextMedContextService.isEnabled(FeatureToggleConfig.SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK) }
-        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @ParameterizedTest
     @EnumSource(KommunerIFinnmarkOgNordTroms::class)
-    fun `send melding til ba-sak hvis person flytter fra en kommune som ikke har Finnmarkstillleg til en av kommune som skal ha Finnmarkstillegg`(input: KommunerIFinnmarkOgNordTroms) {
+    fun `opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis person flytter fra en kommune som ikke har Finnmarkstillleg til en av kommune som skal ha Finnmarkstillegg`(input: KommunerIFinnmarkOgNordTroms) {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
             listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns osloKommunenummer }))
         every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
-        justRun { mockBaSakClient.sendFinnmarkstilleggTilBaSak(personIdent) }
 
         val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, input.kommunenummer, LocalDate.now())
         val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
@@ -173,19 +211,22 @@ class FinnmarkstilleggTaskTest {
         finnmarkstilleggTask.doTask(task)
 
         // Assert
+        val taskSlot = slot<Task>()
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 1) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(personIdent) }
+        verify(exactly = 1) { mockTaskService.save(capture(taskSlot)) }
+
+        assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
+        assertThat(taskSlot.captured.type).isEqualTo(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
     }
 
     @ParameterizedTest
     @EnumSource(KommunerIFinnmarkOgNordTroms::class)
-    fun `send melding til ba-sak hvis person flytter fra en av kommune som skal ha Finnmarkstillegg til en kommune som ikke har Finnmarkstillegg`(input: KommunerIFinnmarkOgNordTroms) {
+    fun `opprett TriggFinnmarkstilleggbehandlingIBaSakTask hvis person flytter fra en av kommune som skal ha Finnmarkstillegg til en kommune som ikke har Finnmarkstillegg`(input: KommunerIFinnmarkOgNordTroms) {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
             listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns input.kommunenummer }))
         every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
-        justRun { mockBaSakClient.sendFinnmarkstilleggTilBaSak(personIdent) }
 
         val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, osloKommunenummer, LocalDate.now())
         val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
@@ -194,8 +235,37 @@ class FinnmarkstilleggTaskTest {
         finnmarkstilleggTask.doTask(task)
 
         // Assert
+        val taskSlot = slot<Task>()
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
         verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 1) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(personIdent) }
+        verify(exactly = 1) { mockTaskService.save(capture(taskSlot)) }
+
+        assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
+        assertThat(taskSlot.captured.type).isEqualTo(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
+    }
+
+    @Test
+    fun `opprett TriggFinnmarkstilleggbehandlingIBaSakTask med riktig triggertid i prod`() {
+        // Arrange
+        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR).bostedsadresse } returns
+            listOf(Bostedsadresse(gyldigFraOgMed = LocalDate.parse("2022-01-01"), vegadresse = mockk { every { kommunenummer } returns ALTA.kommunenummer }))
+        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
+        every { mockEnvironment.activeProfiles } returns arrayOf("prod")
+
+        val taskDto = VurderFinnmarkstillleggTaskDTO(personIdent, osloKommunenummer, LocalDate.now())
+        val task = Task(FinnmarkstilleggTask.TASK_STEP_TYPE, objectMapper.writeValueAsString(taskDto))
+
+        // Act
+        finnmarkstilleggTask.doTask(task)
+
+        // Assert
+        val taskSlot = slot<Task>()
+        verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-bostedsadresse", Tema.BAR) }
+        verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
+        verify(exactly = 1) { mockTaskService.save(capture(taskSlot)) }
+
+        assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
+        assertThat(taskSlot.captured.type).isEqualTo(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
+        assertThat(taskSlot.captured.triggerTid).isEqualTo(LocalDateTime.of(2025, 11, 1, 0, 0))
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTaskTest.kt
@@ -1,35 +1,47 @@
 package no.nav.familie.baks.mottak.task
 
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig
-import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
 import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
+import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE
+import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
+import org.springframework.core.env.Environment
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.test.Test
 
 class SvalbardtilleggTaskTest {
     private val mockBaSakClient: BaSakClient = mockk()
     private val mockPdlClient: PdlClient = mockk()
-    private val mockUnleashNextMedContextService: UnleashNextMedContextService = mockk(relaxed = true)
-    private val svalbardtilleggTask = SvalbardtilleggTask(mockPdlClient, mockBaSakClient, mockUnleashNextMedContextService)
+    private val mockTaskService: TaskService = mockk()
+    private val mockEnvironment: Environment = mockk(relaxed = true)
+    private val svalbardtilleggTask = SvalbardtilleggTask(mockPdlClient, mockBaSakClient, mockTaskService, mockEnvironment)
     private val personIdent = "123"
 
     @BeforeEach
     fun setUp() {
-        every { mockUnleashNextMedContextService.isEnabled(any()) } returns true
+        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
+            listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD.name))
+        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
+        every { mockTaskService.finnTaskMedPayloadOgType(any(), any()) } returns null
+        every { mockTaskService.save(any()) } returns mockk()
     }
 
     @Test
-    fun `ìkke send melding om Svalbardtillegg hvis person ikke har oppholdsadresse`() {
+    fun `ìkke opprett TriggSvalbardtilleggbehandlingIBaSakTask hvis person ikke har oppholdsadresse`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns emptyList()
 
@@ -40,12 +52,13 @@ class SvalbardtilleggTaskTest {
 
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
+        verify(exactly = 0) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendSvalbardtilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ìkke send melding om Svalbardtillegg hvis person har oppholdsadresse annet sted enn Svalbard`() {
+    fun `ìkke opprett TriggSvalbardtilleggbehandlingIBaSakTask hvis person har oppholdsadresse annet sted enn Svalbard`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
             listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), oppholdAnnetSted = OppholdAnnetSted.UTENRIKS.name))
@@ -57,15 +70,48 @@ class SvalbardtilleggTaskTest {
 
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
+        verify(exactly = 0) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
         verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
-        verify(exactly = 0) { mockBaSakClient.sendSvalbardtilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
-    @Test
-    fun `ikke send melding om Svalbardtillegg hvis person ikke har noen løpende saker`() {
+    @ParameterizedTest
+    @EnumSource(value = Status::class, names = ["KLAR_TIL_PLUKK", "UBEHANDLET"], mode = INCLUDE)
+    fun `hopp ut av SvalbardtilleggTask som følge av eksisterende ukjørt TriggSvalbardtilleggbehandlingIBaSakTask for ident`(
+        status: Status,
+    ) {
         // Arrange
-        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
-            listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD.name))
+        every { mockTaskService.finnTaskMedPayloadOgType(any(), any()) } returns
+            Task(
+                type = TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE,
+                payload = personIdent,
+                status = status,
+            )
+
+        val task = Task(SvalbardtilleggTask.TASK_STEP_TYPE, personIdent)
+
+        // Act
+        svalbardtilleggTask.doTask(task)
+
+        // Assert
+        verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
+        verify(exactly = 0) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status::class, names = ["KLAR_TIL_PLUKK", "UBEHANDLET"], mode = EXCLUDE)
+    fun `ikke hopp ut av SvalbardtilleggTask som følge av eksisterende ferdigkjørt TriggSvalbardtilleggbehandlingIBaSakTask for ident`(
+        status: Status,
+    ) {
+        // Arrange
+        every { mockTaskService.finnTaskMedPayloadOgType(any(), any()) } returns
+            Task(
+                type = TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE,
+                payload = personIdent,
+                status = status,
+            )
         every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns emptyList()
 
         val task = Task(SvalbardtilleggTask.TASK_STEP_TYPE, personIdent)
@@ -75,17 +121,15 @@ class SvalbardtilleggTaskTest {
 
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
-        verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 0) { mockBaSakClient.sendSvalbardtilleggTilBaSak(any()) }
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
+        verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `ikke send melding om Svalbardtillegg hvis toggle er skrudd av`() {
+    fun `ikke opprett TriggSvalbardtilleggbehandlingIBaSakTask hvis person ikke har noen løpende saker`() {
         // Arrange
-        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
-            listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD.name))
-        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
-        every { mockUnleashNextMedContextService.isEnabled(FeatureToggleConfig.SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK) } returns false
+        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns emptyList()
 
         val task = Task(SvalbardtilleggTask.TASK_STEP_TYPE, personIdent)
 
@@ -94,18 +138,16 @@ class SvalbardtilleggTaskTest {
 
         // Assert
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
         verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 1) { mockUnleashNextMedContextService.isEnabled(FeatureToggleConfig.SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK) }
-        verify(exactly = 0) { mockBaSakClient.sendSvalbardtilleggTilBaSak(any()) }
+        verify(exactly = 0) { mockTaskService.save(any()) }
     }
 
     @Test
-    fun `send melding til ba-sak hvis person flytter til Svalbard`() {
+    fun `opprett TriggSvalbardtilleggbehandlingIBaSakTask hvis person flytter til Svalbard`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
             listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD.name))
-        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
-        justRun { mockBaSakClient.sendSvalbardtilleggTilBaSak(personIdent) }
 
         val task = Task(SvalbardtilleggTask.TASK_STEP_TYPE, personIdent)
 
@@ -113,18 +155,21 @@ class SvalbardtilleggTaskTest {
         svalbardtilleggTask.doTask(task)
 
         // Assert
+        val taskSlot = slot<Task>()
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
         verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 1) { mockBaSakClient.sendSvalbardtilleggTilBaSak(personIdent) }
+        verify(exactly = 1) { mockTaskService.save(capture(taskSlot)) }
+
+        assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
+        assertThat(taskSlot.captured.type).isEqualTo(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
     }
 
     @Test
-    fun `send melding til ba-sak hvis person flytter fra Svalbard`() {
+    fun `opprett TriggSvalbardtilleggbehandlingIBaSakTask hvis person flytter fra Svalbard`() {
         // Arrange
         every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
             listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), gyldigTilOgMed = LocalDate.of(2025, 8, 31), oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD.name))
         every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
-        justRun { mockBaSakClient.sendSvalbardtilleggTilBaSak(personIdent) }
 
         val task = Task(SvalbardtilleggTask.TASK_STEP_TYPE, personIdent)
 
@@ -132,8 +177,38 @@ class SvalbardtilleggTaskTest {
         svalbardtilleggTask.doTask(task)
 
         // Assert
+        val taskSlot = slot<Task>()
         verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
         verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
-        verify(exactly = 1) { mockBaSakClient.sendSvalbardtilleggTilBaSak(personIdent) }
+        verify(exactly = 1) { mockTaskService.save(capture(taskSlot)) }
+
+        assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
+        assertThat(taskSlot.captured.type).isEqualTo(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
+    }
+
+    @Test
+    fun `opprett TriggSvalbardtilleggbehandlingIBaSakTask med riktig triggertid i prod`() {
+        // Arrange
+        every { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR).oppholdsadresse } returns
+            listOf(Oppholdsadresse(gyldigFraOgMed = LocalDate.of(2025, 1, 1), gyldigTilOgMed = LocalDate.of(2025, 8, 31), oppholdAnnetSted = OppholdAnnetSted.PAA_SVALBARD.name))
+        every { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) } returns listOf(mockk())
+        every { mockEnvironment.activeProfiles } returns arrayOf("prod")
+
+        val task = Task(SvalbardtilleggTask.TASK_STEP_TYPE, personIdent)
+
+        // Act
+        svalbardtilleggTask.doTask(task)
+
+        // Assert
+        val taskSlot = slot<Task>()
+        verify(exactly = 1) { mockPdlClient.hentPerson(personIdent, "hentperson-med-oppholdsadresse", Tema.BAR) }
+        verify(exactly = 1) { mockTaskService.finnTaskMedPayloadOgType(personIdent, TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE) }
+        verify(exactly = 1) { mockBaSakClient.hentFagsakerHvorPersonErSøkerEllerMottarOrdinærBarnetrygd(personIdent) }
+        verify(exactly = 1) { mockTaskService.save(capture(taskSlot)) }
+
+        assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
+        assertThat(taskSlot.captured.type).isEqualTo(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
+        assertThat(taskSlot.captured.triggerTid).isAfterOrEqualTo(LocalDateTime.of(2025, 11, 1, 0, 0))
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/TriggFinnmarkstilleggbehandlingIBaSakTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/TriggFinnmarkstilleggbehandlingIBaSakTaskTest.kt
@@ -1,0 +1,64 @@
+package no.nav.familie.baks.mottak.task
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig.Companion.SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class TriggFinnmarkstilleggbehandlingIBaSakTaskTest {
+    private val mockBaSakClient: BaSakClient = mockk()
+    private val mockUnleashService: UnleashNextMedContextService = mockk()
+    private val triggFinnmarkstilleggbehandlingIBaSakTask =
+        TriggFinnmarkstilleggbehandlingIBaSakTask(
+            baSakClient = mockBaSakClient,
+            unleashNextMedContextService = mockUnleashService,
+        )
+
+    private val personIdent = "12345678910"
+
+    @Test
+    fun `skal sende finnmarkstillegg til ba-sak når feature toggle er aktivert`() {
+        // Arrange
+        every { mockUnleashService.isEnabled(SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK) } returns true
+        justRun { mockBaSakClient.sendFinnmarkstilleggTilBaSak(personIdent) }
+
+        val task = Task(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE, personIdent)
+
+        // Act
+        triggFinnmarkstilleggbehandlingIBaSakTask.doTask(task)
+
+        // Assert
+        verify(exactly = 1) { mockUnleashService.isEnabled(SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK) }
+        verify(exactly = 1) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(personIdent) }
+    }
+
+    @Test
+    fun `skal kaste RekjørSenereException når feature toggle er deaktivert`() {
+        // Arrange
+        every { mockUnleashService.isEnabled(SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK) } returns false
+
+        val task = Task(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE, personIdent)
+        val omEnUke = LocalDate.now().plusWeeks(1)
+
+        // Act & Assert
+        val exception =
+            assertThrows<RekjørSenereException> {
+                triggFinnmarkstilleggbehandlingIBaSakTask.doTask(task)
+            }
+
+        assertThat(exception.årsak).isEqualTo("Toggle er skrudd av, prøver igjen om 1 uke")
+        assertThat(exception.triggerTid.toLocalDate()).isEqualTo(omEnUke)
+
+        verify(exactly = 1) { mockUnleashService.isEnabled(SEND_BOSTEDSADRESSE_HENDELSER_TIL_BA_SAK) }
+        verify(exactly = 0) { mockBaSakClient.sendFinnmarkstilleggTilBaSak(any()) }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/TriggSvalbardtilleggbehandlingIBaSakTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/TriggSvalbardtilleggbehandlingIBaSakTaskTest.kt
@@ -1,0 +1,64 @@
+package no.nav.familie.baks.mottak.task
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleConfig.Companion.SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK
+import no.nav.familie.baks.mottak.config.featureToggle.UnleashNextMedContextService
+import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class TriggSvalbardtilleggbehandlingIBaSakTaskTest {
+    private val mockBaSakClient: BaSakClient = mockk()
+    private val mockUnleashService: UnleashNextMedContextService = mockk()
+    private val triggSvalbardtilleggbehandlingIBaSakTask =
+        TriggSvalbardtilleggbehandlingIBaSakTask(
+            baSakClient = mockBaSakClient,
+            unleashNextMedContextService = mockUnleashService,
+        )
+
+    private val personIdent = "12345678910"
+
+    @Test
+    fun `skal sende svalbardtillegg til ba-sak når feature toggle er aktivert`() {
+        // Arrange
+        every { mockUnleashService.isEnabled(SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK) } returns true
+        justRun { mockBaSakClient.sendSvalbardtilleggTilBaSak(personIdent) }
+
+        val task = Task(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE, personIdent)
+
+        // Act
+        triggSvalbardtilleggbehandlingIBaSakTask.doTask(task)
+
+        // Assert
+        verify(exactly = 1) { mockUnleashService.isEnabled(SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK) }
+        verify(exactly = 1) { mockBaSakClient.sendSvalbardtilleggTilBaSak(personIdent) }
+    }
+
+    @Test
+    fun `skal kaste RekjørSenereException når feature toggle er deaktivert`() {
+        // Arrange
+        every { mockUnleashService.isEnabled(SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK) } returns false
+
+        val task = Task(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE, personIdent)
+        val omEnUke = LocalDate.now().plusWeeks(1)
+
+        // Act & Assert
+        val exception =
+            assertThrows<RekjørSenereException> {
+                triggSvalbardtilleggbehandlingIBaSakTask.doTask(task)
+            }
+
+        assertThat(exception.årsak).isEqualTo("Toggle er skrudd av, prøver igjen om 1 uke")
+        assertThat(exception.triggerTid.toLocalDate()).isEqualTo(omEnUke)
+
+        verify(exactly = 1) { mockUnleashService.isEnabled(SEND_OPPHOLDSADRESSE_HENDELSER_TIL_BA_SAK) }
+        verify(exactly = 0) { mockBaSakClient.sendSvalbardtilleggTilBaSak(any()) }
+    }
+}


### PR DESCRIPTION
Favro: [NAV-26405](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26405)

Legger til en egen task som trigger finnmarks- eller svalbardtilleggbehandlinger i ba-sak. Den eksisterende tasken kjøres nå med en gang og filtrerer bort hendelser som er irrelevante, og oppretter task for identene som skal sendes til ba-sak.

Identer sendes tidligst til ba-sak 1. november

I tasken som sender ident til ba-sak kastes det en `RekjørSenereException` dersom toggle ikke er skrudd på. Hvis dette ikke gjøres vil tasken settes til `Ferdig` uten å gjøre noe, og bli glemt. Kom gjerne med et bedre forslag til et sikkerhetsnett her ¯\\\_(ツ)_/¯