### PR TITLE
Fiks tidssensitiv test

### DIFF
--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
@@ -16,6 +16,8 @@ import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.byLessThan
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -24,6 +26,7 @@ import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
 import org.springframework.core.env.Environment
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import kotlin.test.Test
 
 class FinnmarkstilleggTaskTest {
@@ -266,6 +269,6 @@ class FinnmarkstilleggTaskTest {
 
         assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
         assertThat(taskSlot.captured.type).isEqualTo(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
-        assertThat(taskSlot.captured.triggerTid).isEqualTo(LocalDateTime.of(2025, 11, 1, 0, 0))
+        assertThat(taskSlot.captured.triggerTid).isCloseTo(LocalDateTime.now().plusHours(1), byLessThan(1, ChronoUnit.MINUTES))
     }
 }


### PR DESCRIPTION
Gjorde tidligere en sjekk mot hardkodet dato. Endrer det til å sjekke en time frem i tid, med litt slingringsmonn.