### PR TITLE
Endre triggertid på adressehendelser til tidligst 1. desember

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTask.kt
@@ -108,8 +108,7 @@ class FinnmarkstilleggTask(
     private fun finnTriggertidForÅSendeIdentTilBaSak(): LocalDateTime =
         LocalDateTime.now().run {
             if (environment.activeProfiles.contains("prod")) {
-                val tidligsteTriggerTid = LocalDateTime.of(2025, 11, 1, 0, 0)
-                plusHours(1).coerceAtLeast(tidligsteTriggerTid)
+                plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak)
             } else {
                 this
             }
@@ -117,6 +116,7 @@ class FinnmarkstilleggTask(
 
     companion object {
         const val TASK_STEP_TYPE = "finnmarkstilleggTask"
+        val tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak = LocalDateTime.of(2025, 12, 1, 0, 0)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTask.kt
@@ -77,8 +77,7 @@ class SvalbardtilleggTask(
     private fun finnTriggertidForÅSendeIdentTilBaSak(): LocalDateTime =
         LocalDateTime.now().run {
             if (environment.activeProfiles.contains("prod")) {
-                val tidligsteTriggerTid = LocalDateTime.of(2025, 11, 1, 0, 0)
-                plusHours(1).coerceAtLeast(tidligsteTriggerTid)
+                plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak)
             } else {
                 this
             }
@@ -86,6 +85,7 @@ class SvalbardtilleggTask(
 
     companion object {
         const val TASK_STEP_TYPE = "svalbardtilleggTask"
+        val tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak = LocalDateTime.of(2025, 12, 1, 0, 0)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
@@ -6,6 +6,7 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.baks.mottak.task.FinnmarkstilleggTask.Companion.tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms.ALTA
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms.BERLEVÅG
@@ -17,7 +18,6 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.byLessThan
-import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
 import org.springframework.core.env.Environment
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
+import java.time.temporal.ChronoUnit.MINUTES
 import kotlin.test.Test
 
 class FinnmarkstilleggTaskTest {
@@ -269,6 +269,7 @@ class FinnmarkstilleggTaskTest {
 
         assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
         assertThat(taskSlot.captured.type).isEqualTo(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
-        assertThat(taskSlot.captured.triggerTid).isCloseTo(LocalDateTime.now().plusHours(1), byLessThan(1, ChronoUnit.MINUTES))
+        val forventetTriggerTid = LocalDateTime.now().plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak)
+        assertThat(taskSlot.captured.triggerTid).isCloseTo(forventetTriggerTid, byLessThan(1, MINUTES))
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTaskTest.kt
@@ -6,6 +6,7 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
+import no.nav.familie.baks.mottak.task.SvalbardtilleggTask.Companion.tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
 import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
@@ -13,6 +14,7 @@ import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.byLessThan
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -21,6 +23,7 @@ import org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE
 import org.springframework.core.env.Environment
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit.MINUTES
 import kotlin.test.Test
 
 class SvalbardtilleggTaskTest {
@@ -209,6 +212,7 @@ class SvalbardtilleggTaskTest {
 
         assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
         assertThat(taskSlot.captured.type).isEqualTo(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
-        assertThat(taskSlot.captured.triggerTid).isAfterOrEqualTo(LocalDateTime.of(2025, 11, 1, 0, 0))
+        val forventetTriggerTid = LocalDateTime.now().plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak)
+        assertThat(taskSlot.captured.triggerTid).isCloseTo(forventetTriggerTid, byLessThan(1, MINUTES))
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-26288

### 💰 Hva skal gjøres, og hvorfor?
Tidligere ble triggertiden på tasker som oppretter Finnmarks- og Svalbardtillegg i ba-sak endret til et senere tidspunkt, men koden ble ikke endret, så tasker opprettes fortsatt med triggertid 1. november.

Endrer triggertiden til 1. desember

Triggertid på eksisterende tasker skal oppdateres når PR'en er merget