### PR TITLE
Fjern tidligste kjøretid for finnmarkstilleggtasker

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTask.kt
@@ -108,7 +108,7 @@ class FinnmarkstilleggTask(
     private fun finnTriggertidForÅSendeIdentTilBaSak(): LocalDateTime =
         LocalDateTime.now().run {
             if (environment.activeProfiles.contains("prod")) {
-                plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak)
+                plusHours(1)
             } else {
                 this
             }
@@ -116,7 +116,6 @@ class FinnmarkstilleggTask(
 
     companion object {
         const val TASK_STEP_TYPE = "finnmarkstilleggTask"
-        val tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak = LocalDateTime.of(2025, 12, 1, 0, 0)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/FinnmarkstilleggTaskTest.kt
@@ -6,7 +6,6 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
-import no.nav.familie.baks.mottak.task.FinnmarkstilleggTask.Companion.tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms.ALTA
 import no.nav.familie.kontrakter.ba.finnmarkstillegg.KommunerIFinnmarkOgNordTroms.BERLEVÅG
@@ -269,7 +268,6 @@ class FinnmarkstilleggTaskTest {
 
         assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
         assertThat(taskSlot.captured.type).isEqualTo(TriggFinnmarkstilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
-        val forventetTriggerTid = LocalDateTime.now().plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeFinnmarkstilleggTilBaSak)
-        assertThat(taskSlot.captured.triggerTid).isCloseTo(forventetTriggerTid, byLessThan(1, MINUTES))
+        assertThat(taskSlot.captured.triggerTid).isCloseTo(LocalDateTime.now().plusHours(1), byLessThan(1, MINUTES))
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-26288

### 💰 Hva skal gjøres, og hvorfor?
Vi har gått live med adressehendelser og ønsker derfor å kjøre tasker etter én time i prod. 
Fjerner tidligste 1. desember som tidligste kjøretid

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.