### PR TITLE
Fjern tidligste triggertid fra Svalbardtilleggtasker

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTask.kt
@@ -77,7 +77,7 @@ class SvalbardtilleggTask(
     private fun finnTriggertidForÅSendeIdentTilBaSak(): LocalDateTime =
         LocalDateTime.now().run {
             if (environment.activeProfiles.contains("prod")) {
-                plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak)
+                plusHours(1)
             } else {
                 this
             }
@@ -85,7 +85,6 @@ class SvalbardtilleggTask(
 
     companion object {
         const val TASK_STEP_TYPE = "svalbardtilleggTask"
-        val tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak = LocalDateTime.of(2025, 12, 1, 0, 0)
         private val secureLogger = LoggerFactory.getLogger("secureLogger")
     }
 }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/SvalbardtilleggTaskTest.kt
@@ -6,7 +6,6 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.PdlClient
-import no.nav.familie.baks.mottak.task.SvalbardtilleggTask.Companion.tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.personopplysning.OppholdAnnetSted
 import no.nav.familie.kontrakter.felles.personopplysning.Oppholdsadresse
@@ -212,7 +211,6 @@ class SvalbardtilleggTaskTest {
 
         assertThat(taskSlot.captured.payload).isEqualTo(personIdent)
         assertThat(taskSlot.captured.type).isEqualTo(TriggSvalbardtilleggbehandlingIBaSakTask.TASK_STEP_TYPE)
-        val forventetTriggerTid = LocalDateTime.now().plusHours(1).coerceAtLeast(tidligsteTriggerTidForÅSendeSvalbardtilleggTilBaSak)
-        assertThat(taskSlot.captured.triggerTid).isCloseTo(forventetTriggerTid, byLessThan(1, MINUTES))
+        assertThat(taskSlot.captured.triggerTid).isCloseTo(LocalDateTime.now().plusHours(1), byLessThan(1, MINUTES))
     }
 }


### PR DESCRIPTION
### 📮 Favro: NAV-26884

### 💰 Hva skal gjøres, og hvorfor?
Vi har gått live med Svalbardtillegg, så vi vil at taskene skal kjøre etter 1 time, ikke tidligst 01.12

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.