### PR TITLE
Eksluder spring avhengigheter fra prod-avhengigheter for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,6 +32,7 @@ updates:
       prod-avhengigheter:
         dependency-type: production
         exclude-patterns:
+          - "org.springframework*"
           - "no.nav.security*"
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
### 📮 Favro: N/A

### 💰 Hva skal gjøres, og hvorfor?
Setter at dependabot PR-er for spring blir gruppert i gruppen "spring-avhengigheter", fremfor "prod-avhengigheter".

Testet her og det funket fint:
https://github.com/navikt/familie-baks-soknad-api/pull/481 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant