### PR TITLE
Fjern Kotlin-kompileringsvarsler for annoteringer uten use-site target

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/domene/Hendelseslogg.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/domene/Hendelseslogg.kt
@@ -17,23 +17,23 @@ import java.util.Properties
 @Entity
 @Table(name = "HENDELSESLOGG")
 data class Hendelseslogg(
-    @Column(name = "kafka_offset")
+    @field:Column(name = "kafka_offset")
     val offset: Long,
-    @Column(name = "hendelse_id")
+    @field:Column(name = "hendelse_id")
     val hendelseId: String,
-    @Enumerated(EnumType.STRING)
-    @Column(name = "consumer")
+    @field:Enumerated(EnumType.STRING)
+    @field:Column(name = "consumer")
     val consumer: HendelseConsumer,
-    @Convert(converter = PropertiesToStringConverter::class)
-    @Column(name = "metadata")
+    @field:Convert(converter = PropertiesToStringConverter::class)
+    @field:Column(name = "metadata")
     val metadata: Properties = Properties(),
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hendelseslogg_seq")
-    @SequenceGenerator(name = "hendelseslogg_seq")
+    @field:Id
+    @field:GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hendelseslogg_seq")
+    @field:SequenceGenerator(name = "hendelseslogg_seq")
     val id: Long? = null,
-    @Column(name = "opprettet_tid", nullable = false, updatable = false)
+    @field:Column(name = "opprettet_tid", nullable = false, updatable = false)
     val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
-    @Column(name = "ident", nullable = true)
+    @field:Column(name = "ident", nullable = true)
     val ident: String? = null,
 )
 

--- a/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/hendelser/LeesahService.kt
@@ -42,7 +42,7 @@ import kotlin.random.Random.Default.nextLong
 class LeesahService(
     private val hendelsesloggRepository: HendelsesloggRepository,
     private val taskService: TaskService,
-    @Value("\${FØDSELSHENDELSE_VENT_PÅ_TPS_MINUTTER}") private val triggerTidForTps: Long,
+    @param:Value("\${FØDSELSHENDELSE_VENT_PÅ_TPS_MINUTTER}") private val triggerTidForTps: Long,
     private val environment: Environment,
 ) {
     val dødsfallCounter: Counter = Metrics.counter("dodsfall")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/ArbeidsfordelingClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/ArbeidsfordelingClient.kt
@@ -20,7 +20,7 @@ import java.util.Optional.ofNullable
 @Component
 class ArbeidsfordelingClient(
     @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
-    @Qualifier("integrasjonerRestClient") private val restClient: RestClient,
+    @param:Qualifier("integrasjonerRestClient") private val restClient: RestClient,
     private val featureToggleService: FeatureToggleService,
 ) {
     fun hentBehandlendeEnheterPåIdent(

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BaksVersjonertSøknadClient.kt
@@ -16,7 +16,7 @@ private val logger = LoggerFactory.getLogger(BaksVersjonertSøknadClient::class.
 @Component
 class BaksVersjonertSøknadClient(
     @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonerServiceUri: URI,
-    @Qualifier("integrasjonerRestClient") private val restClient: RestClient,
+    @param:Qualifier("integrasjonerRestClient") private val restClient: RestClient,
 ) {
     fun hentVersjonertBarnetrygdSøknad(journalpostId: String): VersjonertBarnetrygdSøknad {
         val uri = URI.create("$integrasjonerServiceUri/baks/versjonertsoknad/ba/$journalpostId")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/DokarkivClient.kt
@@ -21,7 +21,7 @@ private val logger = LoggerFactory.getLogger(DokarkivClient::class.java)
 @Component
 class DokarkivClient(
     @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
-    @Qualifier("integrasjonerRestClient") private val restClient: RestClient,
+    @param:Qualifier("integrasjonerRestClient") private val restClient: RestClient,
 ) {
     fun oppdaterJournalpostSak(
         jp: Journalpost,

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/FamilieDokumentClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/FamilieDokumentClient.kt
@@ -15,8 +15,8 @@ private val logger = LoggerFactory.getLogger(FamilieDokumentClient::class.java)
 @Component
 class FamilieDokumentClient(
     @param:Value("\${FAMILIE_DOKUMENT_API_URL}") private val dokumentUri: URI,
-    @Qualifier("unauthenticatedRestClient") private val unauthenticatedRestClient: RestClient,
-    @Qualifier("familieTokenXRestClient") private val restClient: RestClient,
+    @param:Qualifier("unauthenticatedRestClient") private val unauthenticatedRestClient: RestClient,
+    @param:Qualifier("familieTokenXRestClient") private val restClient: RestClient,
 ) {
     fun hentVedlegg(dokumentId: String): ByteArray {
         logger.info("Henter vedlegg med dokumentid $dokumentId")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/HentEnhetClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/HentEnhetClient.kt
@@ -14,7 +14,7 @@ private val logger = LoggerFactory.getLogger(HentEnhetClient::class.java)
 @Component
 class HentEnhetClient(
     @param:Value("\${NORG2_API_URL}") private val norg2Uri: URI,
-    @Qualifier("unauthenticatedRestClient") private val restClient: RestClient,
+    @param:Qualifier("unauthenticatedRestClient") private val restClient: RestClient,
 ) {
     fun hentEnhet(enhetId: String): Enhet {
         val uri = URI.create("$norg2Uri/api/v1/enhet/$enhetId")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdBarnetrygdClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/InfotrygdBarnetrygdClient.kt
@@ -13,8 +13,8 @@ import no.nav.familie.kontrakter.ba.infotrygd.Stønad as StønadDto
 
 @Component
 class InfotrygdBarnetrygdClient(
-    @Value("\${FAMILIE_BA_INFOTRYGD_API_URL}/infotrygd/barnetrygd") private val clientUri: URI,
-    @Value("\${FAMILIE_BA_INFOTRYGD_SCOPE}") private val infotrygdScope: String,
+    @param:Value("\${FAMILIE_BA_INFOTRYGD_API_URL}/infotrygd/barnetrygd") private val clientUri: URI,
+    @param:Value("\${FAMILIE_BA_INFOTRYGD_SCOPE}") private val infotrygdScope: String,
     entraIDRestClientFactory: EntraIDRestClientFactory,
 ) {
     private val restClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(infotrygdScope)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/JournalpostClient.kt
@@ -21,7 +21,7 @@ class JournalpostClient
     @Autowired
     constructor(
         @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonerServiceUri: URI,
-        @Qualifier("integrasjonerRestClient") private val restClient: RestClient,
+        @param:Qualifier("integrasjonerRestClient") private val restClient: RestClient,
     ) {
         fun hentJournalpost(journalpostId: String): Journalpost {
             val uri = URI.create("$integrasjonerServiceUri/journalpost?journalpostId=$journalpostId")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/OppgaveClient.kt
@@ -31,7 +31,7 @@ class OppgaveClient
     @Autowired
     constructor(
         @param:Value("\${FAMILIE_INTEGRASJONER_API_URL}") private val integrasjonUri: URI,
-        @Qualifier("integrasjonerRestClient") private val restClient: RestClient,
+        @param:Qualifier("integrasjonerRestClient") private val restClient: RestClient,
         private val oppgaveMapperService: OppgaveMapperService,
     ) {
         val secureLog: Logger = LoggerFactory.getLogger("secureLogger")

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/PdlClient.kt
@@ -275,10 +275,10 @@ data class PdlPersonData(
     val forelderBarnRelasjon: List<PdlForeldreBarnRelasjon> = emptyList(),
     val adressebeskyttelse: List<Adressebeskyttelse> = emptyList(),
     val bostedsadresse: List<Bostedsadresse?> = emptyList(),
-    @field:JsonProperty(value = "doedsfall") val dødsfall: List<Dødsfall> = emptyList(),
-    @field:JsonProperty(value = "foedselsdato") val fødsel: List<Fødsel> = emptyList(),
+    @param:JsonProperty(value = "doedsfall") val dødsfall: List<Dødsfall> = emptyList(),
+    @param:JsonProperty(value = "foedselsdato") val fødsel: List<Fødsel> = emptyList(),
     val sivilstand: List<Sivilstand> = emptyList(),
-    @field:JsonProperty(value = "foedested") val fødested: List<Fødested> = emptyList(),
+    @param:JsonProperty(value = "foedested") val fødested: List<Fødested> = emptyList(),
     val oppholdsadresse: List<Oppholdsadresse> = emptyList(),
     val falskIdentitet: FalskIdentitet? = null,
 )
@@ -303,17 +303,17 @@ data class PdlMetadata(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Dødsfall(
-    @field:JsonProperty(value = "doedsdato") val dødsdato: LocalDate,
+    @param:JsonProperty(value = "doedsdato") val dødsdato: LocalDate,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Fødsel(
-    @field:JsonProperty(value = "foedselsdato") val fødselsdato: LocalDate,
+    @param:JsonProperty(value = "foedselsdato") val fødselsdato: LocalDate,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Fødested(
-    @field:JsonProperty(value = "foedeland") val fødeland: String,
+    @param:JsonProperty(value = "foedeland") val fødeland: String,
 )
 
 fun Fødested.erUtenforNorge(): Boolean =

--- a/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/PdlClient.kt
@@ -21,8 +21,8 @@ import java.time.LocalDate
 
 @Service
 class PdlClient(
-    @Value("\${PDL_URL}") pdlBaseUrl: URI,
-    @Value("\${PDL_SCOPE}") private val pdlScope: String,
+    @param:Value("\${PDL_URL}") pdlBaseUrl: URI,
+    @param:Value("\${PDL_SCOPE}") private val pdlScope: String,
     entraIDRestClientFactory: EntraIDRestClientFactory,
 ) {
     private val restClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(pdlScope)
@@ -275,10 +275,10 @@ data class PdlPersonData(
     val forelderBarnRelasjon: List<PdlForeldreBarnRelasjon> = emptyList(),
     val adressebeskyttelse: List<Adressebeskyttelse> = emptyList(),
     val bostedsadresse: List<Bostedsadresse?> = emptyList(),
-    @JsonProperty(value = "doedsfall") val dødsfall: List<Dødsfall> = emptyList(),
-    @JsonProperty(value = "foedselsdato") val fødsel: List<Fødsel> = emptyList(),
+    @field:JsonProperty(value = "doedsfall") val dødsfall: List<Dødsfall> = emptyList(),
+    @field:JsonProperty(value = "foedselsdato") val fødsel: List<Fødsel> = emptyList(),
     val sivilstand: List<Sivilstand> = emptyList(),
-    @JsonProperty(value = "foedested") val fødested: List<Fødested> = emptyList(),
+    @field:JsonProperty(value = "foedested") val fødested: List<Fødested> = emptyList(),
     val oppholdsadresse: List<Oppholdsadresse> = emptyList(),
     val falskIdentitet: FalskIdentitet? = null,
 )
@@ -303,17 +303,17 @@ data class PdlMetadata(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Dødsfall(
-    @JsonProperty(value = "doedsdato") val dødsdato: LocalDate,
+    @field:JsonProperty(value = "doedsdato") val dødsdato: LocalDate,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Fødsel(
-    @JsonProperty(value = "foedselsdato") val fødselsdato: LocalDate,
+    @field:JsonProperty(value = "foedselsdato") val fødselsdato: LocalDate,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Fødested(
-    @JsonProperty(value = "foedeland") val fødeland: String,
+    @field:JsonProperty(value = "foedeland") val fødeland: String,
 )
 
 fun Fødested.erUtenforNorge(): Boolean =

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/FamiliePdfClient.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/FamiliePdfClient.kt
@@ -15,8 +15,8 @@ data class PdfResponse(
 
 @Service
 class FamiliePdfClient(
-    @Value("\${FAMILIE_PDF_URL}") private val uri: URI,
-    @Value("\${FAMILIE_PDF_SCOPE}") private val familiePdfScope: String,
+    @param:Value("\${FAMILIE_PDF_URL}") private val uri: URI,
+    @param:Value("\${FAMILIE_PDF_SCOPE}") private val familiePdfScope: String,
     entraIDRestClientFactory: EntraIDRestClientFactory,
 ) {
     private val restClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(familiePdfScope)

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/domene/DBBarnetrygdSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/barnetrygd/domene/DBBarnetrygdSøknad.kt
@@ -21,16 +21,16 @@ import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad as BarnetrygdS�
 @Entity(name = "Soknad")
 @Table(name = "Soknad")
 data class DBBarnetrygdSøknad(
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "soknad_seq_generator")
-    @SequenceGenerator(name = "soknad_seq_generator", sequenceName = "soknad_seq", allocationSize = 50)
+    @field:Id
+    @field:GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "soknad_seq_generator")
+    @field:SequenceGenerator(name = "soknad_seq_generator", sequenceName = "soknad_seq", allocationSize = 50)
     val id: Long = 0,
-    @Column(name = "soknad_json")
+    @field:Column(name = "soknad_json")
     val søknadJson: String,
     val fnr: String,
-    @Column(name = "opprettet_tid")
+    @field:Column(name = "opprettet_tid")
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
-    @Column(name = "journalpost_id")
+    @field:Column(name = "journalpost_id")
     val journalpostId: String? = null,
 ) {
     fun hentVersjonertBarnetrygdSøknad(): StøttetVersjonertBarnetrygdSøknad = jsonMapper.readValue(søknadJson, StøttetVersjonertBarnetrygdSøknad::class.java)
@@ -39,10 +39,10 @@ data class DBBarnetrygdSøknad(
 @Entity(name = "SoknadVedlegg")
 @Table(name = "SoknadVedlegg")
 data class DBVedlegg(
-    @Id
-    @Column(name = "dokument_id")
+    @field:Id
+    @field:Column(name = "dokument_id")
     override val dokumentId: String,
-    @Column(name = "soknad_id")
+    @field:Column(name = "soknad_id")
     override val søknadId: Long,
     override val data: ByteArray,
 ) : Vedlegg

--- a/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/DBKontantstøtteSøknad.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/søknad/kontantstøtte/domene/DBKontantstøtteSøknad.kt
@@ -22,20 +22,20 @@ import no.nav.familie.kontrakter.ks.søknad.v6.KontantstøtteSøknad as Kontants
 @Entity(name = "kontantstotte_soknad")
 @Table(name = "kontantstotte_soknad")
 data class DBKontantstøtteSøknad(
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "kontantstotte_soknad_seq_generator")
-    @SequenceGenerator(
+    @field:Id
+    @field:GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "kontantstotte_soknad_seq_generator")
+    @field:SequenceGenerator(
         name = "kontantstotte_soknad_seq_generator",
         sequenceName = "kontantstotte_soknad_seq",
         allocationSize = 50,
     )
     val id: Long = 0,
-    @Column(name = "soknad_json")
+    @field:Column(name = "soknad_json")
     val søknadJson: String,
     val fnr: String,
-    @Column(name = "opprettet_tid")
+    @field:Column(name = "opprettet_tid")
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
-    @Column(name = "journalpost_id")
+    @field:Column(name = "journalpost_id")
     val journalpostId: String? = null,
 ) {
     fun hentVersjonertKontantstøtteSøknad(): StøttetVersjonertKontantstøtteSøknad = jsonMapper.readValue(søknadJson, StøttetVersjonertKontantstøtteSøknad::class.java)
@@ -54,10 +54,10 @@ fun DBKontantstøtteSøknad.harEøsSteg(): Boolean {
 @Entity(name = "kontantstotte_soknad_vedlegg")
 @Table(name = "kontantstotte_soknad_vedlegg")
 data class DBKontantstotteVedlegg(
-    @Id
-    @Column(name = "dokument_id")
+    @field:Id
+    @field:Column(name = "dokument_id")
     override val dokumentId: String,
-    @Column(name = "soknad_id")
+    @field:Column(name = "soknad_id")
     override val søknadId: Long,
     override val data: ByteArray,
 ) : Vedlegg


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
#### Bakgrunn
Kotlin 2.x innfører en endring i hvordan annoteringer uten eksplisitt
use-site target håndteres på konstruktørparametere i klasser med backing
fields. Frem til nå har slike annoteringer kun blitt applisert på
parameteren, men fremover vil de også bli applisert på feltet.
For å unngå uventet oppførsel, og for å tydeliggjøre intensjonen,
er alle annoteringer gitt eksplisitt use-site target.
#### Endringer
**`@field:` — JPA-entiteter og Jackson-deserialisering**
- `Hendelseslogg.kt` – alle JPA-annoteringer
- `DBBarnetrygdSøknad.kt` – alle JPA-annoteringer
- `DBKontantstøtteSøknad.kt` – alle JPA-annoteringer
- `PdlClient.kt` – `@JsonProperty` på data class-parametere
**`@param:` — Spring DI-annoteringer**
- `@Value` i: `PdlClient`, `LeesahService`, `InfotrygdBarnetrygdClient`, `FamiliePdfClient`
- `@Qualifier` i: `ArbeidsfordelingClient`, `BaksVersjonertSøknadClient`, `DokarkivClient`, `FamilieDokumentClient`, `HentEnhetClient`, `JournalpostClient`, `OppgaveClient`

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
