### PR TITLE
fix: prøver å opprette oppgave med ugyldig kombinasjon av behandlingstema

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderAdressebeskyttelsehendelseTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderAdressebeskyttelsehendelseTask.kt
@@ -4,11 +4,11 @@ import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggle.SEND_OPPGAV
 import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleService
 import no.nav.familie.baks.mottak.domene.hendelser.PdlHendelse
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
+import no.nav.familie.baks.mottak.integrasjoner.BehandlingStatus
 import no.nav.familie.baks.mottak.integrasjoner.FagsakStatus
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveClientService
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveVurderLivshendelseDto
 import no.nav.familie.baks.mottak.integrasjoner.PdlClientService
-import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
@@ -23,6 +23,7 @@ import java.util.Properties
     taskStepType = VurderAdressebeskyttelsehendelseTask.TASK_STEP_TYPE,
     beskrivelse = "Oppretter vurder livshendelse oppgave om adressebeskyttelse er opphørt for skjermet barn med løpende fagsak",
     maxAntallFeil = 3,
+    triggerTidVedFeilISekunder = 60,
 )
 class VurderAdressebeskyttelsehendelseTask(
     private val baSakClient: BaSakClient,
@@ -61,13 +62,19 @@ class VurderAdressebeskyttelsehendelseTask(
                 }
 
         if (featureToggleService.isEnabled(SEND_OPPGAVE_OM_ADRESSEBESKYTTELSE_ER_FJERNET)) {
+            val restMinimalFagsak = baSakClient.hentMinimalRestFagsak(løpendeFagsak.id)
+            val sisteBehandling =
+                restMinimalFagsak.behandlinger
+                    .filter { it.status == BehandlingStatus.AVSLUTTET }
+                    .maxByOrNull { it.opprettetTidspunkt }
+
             oppgaveClient.opprettVurderLivshendelseOppgave(
                 OppgaveVurderLivshendelseDto(
                     aktørId = task.payload,
                     beskrivelse = "Adressebeskyttelse er opphevet",
                     saksId = løpendeFagsak.id.toString(),
                     tema = Tema.BAR,
-                    behandlingstema = Behandlingstema.Barnetrygd.value,
+                    behandlingstema = sisteBehandling.tilBarnetrygdBehandlingstema().value,
                     enhetsId = ENHETSNUMMER_VIKAFOSSEN,
                 ),
             )

--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/VurderLivshendelseService.kt
@@ -260,7 +260,7 @@ class VurderLivshendelseService(
         tema: Tema,
         restBehandling: RestVisningBehandling,
     ) = when (tema) {
-        Tema.BAR -> tilBarnetrygdBehandlingstema(restBehandling)
+        Tema.BAR -> restBehandling.tilBarnetrygdBehandlingstema()
 
         // behandlingstema brukes ikke i kombinasjon med behandlingstype for kontantstøtte
         Tema.KON -> null
@@ -396,15 +396,6 @@ class VurderLivshendelseService(
         return listeMedFagsakIdOgTilknyttetAktør
     }
 
-    private fun tilBarnetrygdBehandlingstema(restBehandling: RestVisningBehandling?): Behandlingstema =
-        when {
-            restBehandling == null -> Behandlingstema.Barnetrygd
-            restBehandling.kategori == BehandlingKategori.EØS -> Behandlingstema.BarnetrygdEØS
-            restBehandling.kategori == BehandlingKategori.NASJONAL && restBehandling.underkategori == BehandlingUnderkategori.ORDINÆR -> Behandlingstema.OrdinærBarnetrygd
-            restBehandling.kategori == BehandlingKategori.NASJONAL && restBehandling.underkategori == BehandlingUnderkategori.UTVIDET -> Behandlingstema.UtvidetBarnetrygd
-            else -> Behandlingstema.Barnetrygd
-        }
-
     private fun tilKontanstøtteBehandlingstype(restBehandling: RestVisningBehandling?): Behandlingstype =
         when {
             restBehandling?.kategori == BehandlingKategori.EØS -> Behandlingstype.EØS
@@ -532,3 +523,12 @@ enum class VurderLivshendelseType(
     SIVILSTAND("Endring i sivilstand"),
     UTFLYTTING("Utflytting"),
 }
+
+fun RestVisningBehandling?.tilBarnetrygdBehandlingstema(): Behandlingstema =
+    when {
+        this == null -> Behandlingstema.Barnetrygd
+        this.kategori == BehandlingKategori.EØS -> Behandlingstema.BarnetrygdEØS
+        this.kategori == BehandlingKategori.NASJONAL && this.underkategori == BehandlingUnderkategori.ORDINÆR -> Behandlingstema.OrdinærBarnetrygd
+        this.kategori == BehandlingKategori.NASJONAL && this.underkategori == BehandlingUnderkategori.UTVIDET -> Behandlingstema.UtvidetBarnetrygd
+        else -> Behandlingstema.Barnetrygd
+    }

--- a/src/test/kotlin/no/nav/familie/baks/mottak/task/VurderAdressebeskyttelsehendelseTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/task/VurderAdressebeskyttelsehendelseTaskTest.kt
@@ -9,6 +9,10 @@ import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleService
 import no.nav.familie.baks.mottak.integrasjoner.Adressebeskyttelse
 import no.nav.familie.baks.mottak.integrasjoner.Adressebeskyttelsesgradering
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
+import no.nav.familie.baks.mottak.integrasjoner.BehandlingKategori
+import no.nav.familie.baks.mottak.integrasjoner.BehandlingStatus
+import no.nav.familie.baks.mottak.integrasjoner.BehandlingType
+import no.nav.familie.baks.mottak.integrasjoner.BehandlingUnderkategori
 import no.nav.familie.baks.mottak.integrasjoner.FagsakStatus
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveClientService
 import no.nav.familie.baks.mottak.integrasjoner.OppgaveVurderLivshendelseDto
@@ -16,6 +20,8 @@ import no.nav.familie.baks.mottak.integrasjoner.PdlClientService
 import no.nav.familie.baks.mottak.integrasjoner.PdlMetadata
 import no.nav.familie.baks.mottak.integrasjoner.PdlPersonData
 import no.nav.familie.baks.mottak.integrasjoner.RestFagsakSkjermetBarn
+import no.nav.familie.baks.mottak.integrasjoner.RestMinimalFagsak
+import no.nav.familie.baks.mottak.integrasjoner.RestVisningBehandling
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
@@ -23,6 +29,7 @@ import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 class VurderAdressebeskyttelsehendelseTaskTest {
     private val mockPdlClient: PdlClientService = mockk()
@@ -53,7 +60,7 @@ class VurderAdressebeskyttelsehendelseTaskTest {
     }
 
     @Test
-    fun `skal opprette oppgave når strengt fortrolig adressebeskyttelse er opphørt og løpende fagsak finnes`() {
+    fun `skal opprette oppgave når strengt fortrolig adressebeskyttelse er opphørt og løpende fagsak med kategori ordinær barnetrygd`() {
         // Arrange
         every {
             mockPdlClient.hentPerson(personIdent, "hentperson-med-adressebeskyttelse", Tema.BAR, historikk = true)
@@ -71,6 +78,25 @@ class VurderAdressebeskyttelsehendelseTaskTest {
         every { mockBaSakClient.hentFagsakForSkjermetBarn(personIdent) } returns
             listOf(RestFagsakSkjermetBarn(id = 1L, status = FagsakStatus.LØPENDE))
 
+        every { mockBaSakClient.hentMinimalRestFagsak(1L) } returns
+            RestMinimalFagsak(
+                id = 1L,
+                behandlinger =
+                    listOf(
+                        RestVisningBehandling(
+                            aktiv = true,
+                            behandlingId = 321,
+                            kategori = BehandlingKategori.NASJONAL,
+                            opprettetTidspunkt = LocalDateTime.now(),
+                            resultat = "INNVILGET",
+                            status = BehandlingStatus.AVSLUTTET,
+                            type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                            underkategori = BehandlingUnderkategori.ORDINÆR,
+                        ),
+                    ),
+                status = FagsakStatus.OPPRETTET,
+            )
+
         val oppgaveSlot = slot<OppgaveVurderLivshendelseDto>()
         every { mockOppgaveClient.opprettVurderLivshendelseOppgave(capture(oppgaveSlot)) } returns OppgaveResponse(1L)
 
@@ -83,7 +109,60 @@ class VurderAdressebeskyttelsehendelseTaskTest {
         assertThat(oppgaveSlot.captured.saksId).isEqualTo("1")
         assertThat(oppgaveSlot.captured.tema).isEqualTo(Tema.BAR)
         assertThat(oppgaveSlot.captured.enhetsId).isEqualTo("2103")
-        assertThat(oppgaveSlot.captured.behandlingstema).isEqualTo(Behandlingstema.Barnetrygd.value)
+        assertThat(oppgaveSlot.captured.behandlingstema).isEqualTo(Behandlingstema.OrdinærBarnetrygd.value)
+    }
+
+    @Test
+    fun `skal opprette oppgave når strengt fortrolig adressebeskyttelse er opphørt og løpende fagsak finnes med kategori utvidet barnetrygd`() {
+        // Arrange
+        every {
+            mockPdlClient.hentPerson(personIdent, "hentperson-med-adressebeskyttelse", Tema.BAR, historikk = true)
+        } returns
+            PdlPersonData(
+                adressebeskyttelse =
+                    listOf(
+                        Adressebeskyttelse(
+                            gradering = Adressebeskyttelsesgradering.STRENGT_FORTROLIG,
+                            metadata = PdlMetadata(historisk = true),
+                        ),
+                    ),
+            )
+
+        every { mockBaSakClient.hentFagsakForSkjermetBarn(personIdent) } returns
+            listOf(RestFagsakSkjermetBarn(id = 1L, status = FagsakStatus.LØPENDE))
+
+        every { mockBaSakClient.hentMinimalRestFagsak(1L) } returns
+            RestMinimalFagsak(
+                id = 1L,
+                behandlinger =
+                    listOf(
+                        RestVisningBehandling(
+                            aktiv = true,
+                            behandlingId = 321,
+                            kategori = BehandlingKategori.NASJONAL,
+                            opprettetTidspunkt = LocalDateTime.now(),
+                            resultat = "INNVILGET",
+                            status = BehandlingStatus.AVSLUTTET,
+                            type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                            underkategori = BehandlingUnderkategori.UTVIDET,
+                        ),
+                    ),
+                status = FagsakStatus.OPPRETTET,
+            )
+
+        val oppgaveSlot = slot<OppgaveVurderLivshendelseDto>()
+        every { mockOppgaveClient.opprettVurderLivshendelseOppgave(capture(oppgaveSlot)) } returns OppgaveResponse(1L)
+
+        // Act
+        vurderAdressebeskyttelsehendelseTask.doTask(task)
+
+        // Assert
+        verify(exactly = 1) { mockOppgaveClient.opprettVurderLivshendelseOppgave(any()) }
+        assertThat(oppgaveSlot.captured.aktørId).isEqualTo(aktørId)
+        assertThat(oppgaveSlot.captured.saksId).isEqualTo("1")
+        assertThat(oppgaveSlot.captured.tema).isEqualTo(Tema.BAR)
+        assertThat(oppgaveSlot.captured.enhetsId).isEqualTo("2103")
+        assertThat(oppgaveSlot.captured.behandlingstema).isEqualTo(Behandlingstema.UtvidetBarnetrygd.value)
     }
 
     @Test


### PR DESCRIPTION
### 📮 Favro: NAV-29826

### 💰 Hva skal gjøres, og hvorfor?
Ved oppretting av oppgave for BA, så må man enten sende OrdinærBarnetrygd eller UtvidetBarnetrygd. Gjenbrukt og flyttet logikken i VurderLivshendelseService inn i egen extension funksjon for å utlede behandlingstema for BA

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.