### PR TITLE
Nedgrader database tier til db-f1-micro i dev

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -80,8 +80,8 @@ spec:
       value: "-XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=75.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
   gcp: # Database
     sqlInstances:
-      - type: POSTGRES_17 # IF This is changed, all data will be lost. Read on nais.io how to upgrade
-        tier: db-custom-1-3840
+      - type: POSTGRES_17 # Read on nais.io how to upgrade
+        tier: db-f1-micro
         name: familie-baks-mottak-17
         autoBackupHour: 2
         pointInTimeRecovery: false


### PR DESCRIPTION
Endret database tier from 'db-custom-1-3840' til 'db-f1-micro' for å redusere kostnader