### PR TITLE
Bytt ut TEKNISK_OPPHØR med TEKNISK_ENDRING

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseBarnetrygdRutingTask.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/task/JournalhendelseBarnetrygdRutingTask.kt
@@ -247,13 +247,13 @@ private fun List<RestFagsakDeltager>.harForelderEllerBarnPågåendeSak(baSakClie
 private fun RestFagsakDeltager.harPågåendeSak(baSakClient: BaSakClient): Boolean =
     when (fagsakStatus) {
         OPPRETTET, LØPENDE -> true
-        AVSLUTTET -> !sisteBehandlingHenlagtEllerTekniskOpphør(baSakClient.hentRestFagsak(fagsakId))
+        AVSLUTTET -> !sisteBehandlingHenlagtEllerTekniskEndring(baSakClient.hentRestFagsak(fagsakId))
     }
 
-private fun sisteBehandlingHenlagtEllerTekniskOpphør(fagsak: RestFagsak): Boolean {
+private fun sisteBehandlingHenlagtEllerTekniskEndring(fagsak: RestFagsak): Boolean {
     val sisteBehandling =
         fagsak.behandlinger
             .sortedBy { it.opprettetTidspunkt }
             .findLast { it.steg == "BEHANDLING_AVSLUTTET" } ?: return false
-    return sisteBehandling.type == "TEKNISK_OPPHØR" || sisteBehandling.resultat.startsWith("HENLAGT")
+    return sisteBehandling.type == "TEKNISK_ENDRING" || sisteBehandling.resultat.startsWith("HENLAGT")
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29928

### 💰 Hva skal gjøres, og hvorfor?
`TEKNISK_OPPHØR` er ikke lenger i bruk, alle behandlinger som brukte denne behandlingstypen er migrert over til `TEKNISK_ENDRING`