### PR TITLE
Fjern toggle familie-ba-sak.tillatt-behandling-av-kode6-kode1

### DIFF
--- a/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggle.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/config/featureToggle/FeatureToggle.kt
@@ -5,7 +5,4 @@ enum class FeatureToggle(
 ) {
     // Operasjonelle
     HOPP_OVER_INFOTRYGD_SJEKK("familie-baks-mottak.hopp-over-infotrygd-sjekk"),
-
-    // Operasjonelle
-    AUTOMATISK_JOURNALFØR_ENHET_2103("familie-ba-sak.tillatt-behandling-av-kode6-kode19"),
 }

--- a/src/main/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdService.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.baks.mottak.journalføring
 
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggle
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleService
 import no.nav.familie.baks.mottak.integrasjoner.ArbeidsfordelingClient
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.BarnetrygdOppgaveMapper
@@ -13,7 +11,6 @@ import org.springframework.stereotype.Service
 
 @Service
 class AutomatiskJournalføringBarnetrygdService(
-    private val featureToggleService: FeatureToggleService,
     private val baSakClient: BaSakClient,
     private val arbeidsfordelingClient: ArbeidsfordelingClient,
     private val adressebeskyttelesesgraderingService: AdressebeskyttelesesgraderingService,
@@ -26,14 +23,7 @@ class AutomatiskJournalføringBarnetrygdService(
         journalpost: Journalpost,
         brukerHarSakIInfotrygd: Boolean,
     ): Boolean {
-        val kode6Og19ToggleErPå = featureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false)
-
-        val enheterSomIkkeSkalHaAutomatiskJournalføring =
-            if (kode6Og19ToggleErPå) {
-                listOf("4863")
-            } else {
-                listOf("4863", "2103")
-            }
+        val enheterSomIkkeSkalHaAutomatiskJournalføring = listOf("4863")
 
         if (!journalpost.harBarnetrygdSøknad()) {
             return false
@@ -49,13 +39,9 @@ class AutomatiskJournalføringBarnetrygdService(
 
         val noenHarKode6Eller19 = adressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(tema, journalpost)
 
-        if (kode6Og19ToggleErPå) {
-            val søkerHarKode6Eller19 = adressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(tema, journalpost)
+        val søkerHarKode6Eller19 = adressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpostBruker(tema, journalpost)
 
-            if (!søkerHarKode6Eller19 && noenHarKode6Eller19) {
-                return false
-            }
-        } else if (noenHarKode6Eller19) {
+        if (!søkerHarKode6Eller19 && noenHarKode6Eller19) {
             return false
         }
 

--- a/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/baks/mottak/journalføring/AutomatiskJournalføringBarnetrygdServiceTest.kt
@@ -2,8 +2,6 @@ package no.nav.familie.baks.mottak.journalføring
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggle
-import no.nav.familie.baks.mottak.config.featureToggle.FeatureToggleService
 import no.nav.familie.baks.mottak.integrasjoner.ArbeidsfordelingClient
 import no.nav.familie.baks.mottak.integrasjoner.BaSakClient
 import no.nav.familie.baks.mottak.integrasjoner.BarnetrygdOppgaveMapper
@@ -30,7 +28,6 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class AutomatiskJournalføringBarnetrygdServiceTest {
-    private val mockedFeatureToggleService: FeatureToggleService = mockk()
     private val mockedBaSakClient: BaSakClient = mockk()
     private val mockedArbeidsfordelingClient: ArbeidsfordelingClient = mockk()
     private val mockedAdressebeskyttelesesgraderingService: AdressebeskyttelesesgraderingService = mockk()
@@ -39,7 +36,6 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
     private val automatiskJournalføringBarnetrygdService: AutomatiskJournalføringBarnetrygdService =
         AutomatiskJournalføringBarnetrygdService(
-            featureToggleService = mockedFeatureToggleService,
             baSakClient = mockedBaSakClient,
             arbeidsfordelingClient = mockedArbeidsfordelingClient,
             adressebeskyttelesesgraderingService = mockedAdressebeskyttelesesgraderingService,
@@ -49,7 +45,6 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
 
     @BeforeEach
     internal fun setUp() {
-        every { mockedFeatureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
         every { mockedBarnetrygdOppgaveMapper.hentBehandlingstype(any()) } returns Behandlingstype.NASJONAL
     }
 
@@ -346,56 +341,7 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
     }
 
     @Test
-    fun `skal ikke automatisk journalføre journalpost hvis det finnes en tilknyttet strengt fortrolig person og toggle er ikke på`() {
-        // Arrange
-        every { mockedFeatureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns false
-        val identifikator = "123"
-
-        val journalpost =
-            Journalpost(
-                journalpostId = "1",
-                journalposttype = Journalposttype.I,
-                journalstatus = Journalstatus.MOTTATT,
-                bruker =
-                    Bruker(
-                        id = identifikator,
-                        type = BrukerIdType.FNR,
-                    ),
-                kanal = "NAV_NO",
-                dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            brevkode = "NAV 33-00.07",
-                            tittel = "Søknad",
-                            dokumentstatus = Dokumentstatus.FERDIGSTILT,
-                            dokumentvarianter = emptyList(),
-                            dokumentInfoId = "id",
-                        ),
-                    ),
-            )
-
-        every {
-            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
-                tema = Tema.BAR,
-                journalpost = journalpost,
-            )
-        } returns true
-
-        // Act
-        val skalAutomatiskJournalføres =
-            automatiskJournalføringBarnetrygdService.skalAutomatiskJournalføres(
-                journalpost,
-                false,
-            )
-
-        // Assert
-        assertThat(skalAutomatiskJournalføres).isFalse()
-    }
-
-    @Test
-    fun `skal automatisk journalføre journalpost hvis søker er en strengt fortrolig person og toggle er på`() {
-        every { mockedFeatureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
-
+    fun `skal automatisk journalføre journalpost hvis søker er en strengt fortrolig person`() {
         // Arrange
         val identifikator = "123"
         val fagsakId = 1L
@@ -481,9 +427,7 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
     }
 
     @Test
-    fun `skal ikke automatisk journalføre journalpost hvis søker ikke er en strengt fortrolig person men barna er og toggle er på`() {
-        every { mockedFeatureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
-
+    fun `skal ikke automatisk journalføre journalpost hvis søker ikke er en strengt fortrolig person men barna er`() {
         // Arrange
         val identifikator = "123"
         val fagsakId = 1L
@@ -655,10 +599,8 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
     }
 
     @Test
-    fun `skal ikke automatisk journalføre journalpost hvis enhet er 2103 og toggle er av`() {
+    fun `skal automatisk journalføre journalpost hvis enhet er 2103`() {
         // Arrange
-        every { mockedFeatureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns false
-
         val identifikator = "123"
         val fagsakId = 1L
 
@@ -704,94 +646,6 @@ class AutomatiskJournalføringBarnetrygdServiceTest {
                 behandlinger = listOf(),
                 status = FagsakStatus.LØPENDE,
             )
-
-        every {
-            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
-                tema = Tema.BAR,
-                journalpost = journalpost,
-            )
-        } returns false
-
-        every {
-            mockedArbeidsfordelingClient.hentBehandlendeEnhetPåIdent(
-                personIdent = identifikator,
-                tema = Tema.BAR,
-                behandlingstype = any(),
-            )
-        } returns
-            Enhet(
-                enhetId = "2103",
-                enhetNavn = "Vikafossen",
-            )
-
-        // Act
-        val skalAutomatiskJournalføres =
-            automatiskJournalføringBarnetrygdService.skalAutomatiskJournalføres(
-                journalpost,
-                false,
-            )
-
-        // Assert
-        assertThat(skalAutomatiskJournalføres).isFalse()
-    }
-
-    @Test
-    fun `skal automatisk journalføre journalpost hvis enhet er 2103 og toggle er på`() {
-        // Arrange
-        every { mockedFeatureToggleService.isEnabled(FeatureToggle.AUTOMATISK_JOURNALFØR_ENHET_2103, defaultValue = false) } returns true
-
-        val identifikator = "123"
-        val fagsakId = 1L
-
-        val journalpost =
-            Journalpost(
-                journalpostId = "1",
-                journalposttype = Journalposttype.I,
-                journalstatus = Journalstatus.MOTTATT,
-                bruker =
-                    Bruker(
-                        id = identifikator,
-                        type = BrukerIdType.FNR,
-                    ),
-                kanal = "NAV_NO",
-                dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            brevkode = "NAV 33-00.07",
-                            tittel = "Søknad",
-                            dokumentstatus = Dokumentstatus.FERDIGSTILT,
-                            dokumentvarianter = emptyList(),
-                            dokumentInfoId = "id",
-                        ),
-                    ),
-            )
-
-        every {
-            mockedJournalpostBrukerService.tilPersonIdent(
-                bruker = journalpost.bruker!!,
-                tema = Tema.BAR,
-            )
-        } returns identifikator
-
-        every { mockedBaSakClient.hentFagsaknummerPåPersonident(any()) } returns fagsakId
-
-        every {
-            mockedBaSakClient.hentMinimalRestFagsak(
-                fagsakId = fagsakId,
-            )
-        } returns
-            RestMinimalFagsak(
-                id = fagsakId,
-                behandlinger = listOf(),
-                status = FagsakStatus.LØPENDE,
-            )
-
-        every {
-            mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(
-                tema = Tema.BAR,
-                journalpost = journalpost,
-            )
-        } returns false
 
         every {
             mockedAdressebeskyttelesesgraderingService.finnesStrengtFortroligAdressebeskyttelsegraderingPåJournalpost(


### PR DESCRIPTION
### 📮 Favro: 

### 💰 Hva skal gjøres, og hvorfor?
Togglen familie-ba-sak.tillatt-behandling-av-kode6-kode19 er alltid på i prod. Atferden hardkodes direkte, og togglen ryddes ut.    

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [x] Jeg har skrevet tester.

Husk: Slett selve togglen i Unleash etter merge.  
https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-sak.tillatt-behandling-av-kode6-kode19